### PR TITLE
chore: setup circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,5 +16,5 @@ jobs:
           name: Install Dependencies
           command: yarn install --immutable
       - run:
-          name: test
+          name: Unit Test
           command: yarn test


### PR DESCRIPTION
We want a build now to run our newly added unit tests

**Scope:**
- Do we want to add caching so the build runs faster?
- Should we have another workflow/job for the unit tests or is it fine having the unit tests within `build`?

What the current build looks like:
![Screenshot 2020-12-04 at 14 13 14](https://user-images.githubusercontent.com/36230812/101173771-e1d88a80-363a-11eb-87ac-62a58c867e92.png)
