### PR TITLE
Fix: hide datasources on external links

### DIFF
--- a/src/components/DataLinks/DataLink.tsx
+++ b/src/components/DataLinks/DataLink.tsx
@@ -105,17 +105,19 @@ export const DataLink = (props: Props) => {
             setShowInternalLink(!showInternalLink);
           }}
         />
-        <DataSourcePicker
-          // Uid and value should be always set in the db and so in the items.
-          datasources={datasources}
-          onChange={ds => {
-            onChange({
-              ...value,
-              datasource: ds,
-            });
-          }}
-          current={value.datasource}
-        />
+        {showInternalLink && (
+          <DataSourcePicker
+            // Uid and value should be always set in the db and so in the items.
+            datasources={datasources}
+            onChange={ds => {
+              onChange({
+                ...value,
+                datasource: ds,
+              });
+            }}
+            current={value.datasource}
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
just a quick fix. The datasource picker is not supposed to be shown unless "showInternalLink" is true (enabled)