### PR TITLE
fix: transpile to commonJS instead of es modules

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
-"compilerOptions": {
+  "compilerOptions": {
     "jsx": "react",
     "baseUrl": "node_modules/@types",
     "declarationDir": "dist",
     "outDir": "dist",
     "rootDirs": [".", "stories"],
-},
-"include": ["src"],
-"extends": "@grafana/tsconfig",
-"exclude": ["node_modules", "dist", "compiled"]
+    "module": "CommonJS"
+  },
+  "include": ["src"],
+  "extends": "@grafana/tsconfig",
+  "exclude": ["node_modules", "dist", "compiled"]
 }


### PR DESCRIPTION
Files are currently being built to es modules which give errors when using Jest to run tests for components from other projects which import this:

<img width="949" alt="Screenshot 2021-01-07 at 14 21 34" src="https://user-images.githubusercontent.com/36230812/103905869-0cfd4080-50f7-11eb-89bd-72d8fe21d394.png">

The above error is normally fixed by adding to `transformIgnorePattern` to use babel to transpile correctly (in the project which is trying to imprt from ui-enterprise) but this doesn't work for some reason.

Therefore, we are now simplifying this by transpiling to CommonJS instead.

**Before (dist/index.js):**

```
/**
 * A library containing the different design components of the Grafana enterprise plugins ecosystem.
 *
 * @packageDocumentation
 */
export * from './components';
//# sourceMappingURL=index.js.map
```

**After (dist/index.js):**

```
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
var tslib_1 = require("tslib");
/**
 * A library containing the different design components of the Grafana enterprise plugins ecosystem.
 *
 * @packageDocumentation
 */
tslib_1.__exportStar(require("./components"), exports);
//# sourceMappingURL=index.js.map
```