### PR TITLE
fix: move react-use and chance deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "react-calendar": "^3.2.1",
     "react-dom": "^16.14.0",
     "typescript": "4.0.2",
-    "copyfiles": "^2.4.1"
+    "copyfiles": "^2.4.1",
+    "chance": "^1.1.7",
+    "react-use": "^15.3.4"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
@@ -45,8 +47,6 @@
     "babel-loader": "^8.2.2",
     "@babel/plugin-transform-classes": "7.10.4",
     "@babel/plugin-transform-runtime": "^7.12.10",
-    "react-use": "^15.3.4",
-    "chance": "^1.1.7",
     "mockdate": "^3.0.2",
     "jest-fetch-mock": "^3.0.3",
     "ts-jest": "^26.4.4"


### PR DESCRIPTION
**Problem:**

The `postinstall` step will fail for any projects which import `ui-enterprise` if they do not have `react-use` or `chance` installed.

**Solution:**

Moving `react-use` and `chance` deps from dev deps as `mockDatasource` and `DataLink` are using them and these two are being exported to be used by other projects.

This wasn't noticed before because other plugins which are currently using `ui-enterprise` already have `chance` and `react-use` as deps.