### PR TITLE
chore: add plugin provisioning script for E2E tests

### DIFF
--- a/src/scripts/provision-plugin.sh
+++ b/src/scripts/provision-plugin.sh
@@ -1,0 +1,44 @@
+# To run the E2E tests locally, they are expecting the plugin provisioning datasource yaml file in the correct location
+# This script will grab the yaml file needed and put it in the directory needed
+# If there is already an existing provisioning folder, this wil remove it
+# The user will need access to the plugin-provisioning repository
+# Plugins can use this with bash 
+
+RED=1
+GREEN=2
+
+if (( $# != 1 ))
+then
+  tput setaf $RED; echo "The plugin datasource yaml file name needs to be provided"
+  exit 1
+fi
+
+PARENT_DIR=provisioning
+DIR=$PARENT_DIR/datasources
+
+# If this directory already exists, we can assume we have run this script before
+# so we can just pull the latest from the plugin provisioning repo
+if [[ -d "$PARENT_DIR" ]]
+then
+  git pull &> /dev/null
+
+  echo "Getting latest plugin provisioning repo..."
+else
+  echo "Creating $DIR directory..."
+
+  git clone -n https://github.com/grafana/plugin-provisioning.git --depth 1 $DIR &> /dev/null
+fi
+
+cd $DIR
+
+echo "Getting '$1' provisioning file..."
+
+if git show HEAD:provisioning/datasources/$1.yaml >/dev/null
+then
+  git show HEAD:provisioning/datasources/$1.yaml > $1.yaml
+  tput setaf $GREEN; echo "Provisioned '$1' yaml file."
+  exit 0
+fi
+
+tput setaf $RED; echo "'$1' is not a valid provisioning file."
+exit 1

--- a/src/scripts/provision-plugin.sh
+++ b/src/scripts/provision-plugin.sh
@@ -2,7 +2,6 @@
 # This script will grab the yaml file needed and put it in the directory needed
 # If there is already an existing provisioning folder, this wil remove it
 # The user will need access to the plugin-provisioning repository
-# Plugins can use this with bash 
 
 RED=1
 GREEN=2


### PR DESCRIPTION
In order to run our E2E tests, we require the provisioning yaml file to be in the `<rootDir>/provisioning` folder: https://github.com/grafana/grafana/blob/1d689888b0fc2de2dbed6e606eee19561a3ef006/packages/grafana-e2e/cypress/plugins/readProvisions.js#L12

This is already set up for the build but if we want to debug the tests locally, we would also need this set up.

Adding this script so it can be automated and copied over in our plugins (or if there is some way to export this and use this actual script?) so in the package.json file, we can do something like:

```
{
   "provision-plugin": "bash provision-plugin.sh datadog"
   "e2e:dev": "yarn provision-plugin && grafana-e2e run"
}
```

This script expects the provisioning file name to be passed in so we only grab the one yaml file needed instead of the whole repository.

**First time set up**

File name not passed in

![Screenshot 2021-01-26 at 12 35 36](https://user-images.githubusercontent.com/36230812/105846131-a2437480-5fd3-11eb-9ad6-46cf2dad7764.png)

Invalid file name

![Screenshot 2021-01-26 at 12 35 55](https://user-images.githubusercontent.com/36230812/105846124-9fe11a80-5fd3-11eb-92fd-a512b954a7c8.png)


Valid file name

![Screenshot 2021-01-26 at 12 38 53](https://user-images.githubusercontent.com/36230812/105846079-948def00-5fd3-11eb-9491-18d3e61be27a.png)

**Non-first time set up**

File name not passed in

![Screenshot 2021-01-26 at 12 37 28](https://user-images.githubusercontent.com/36230812/105846109-9d7ec080-5fd3-11eb-98b7-88e1479dcda4.png)

Invalid file name

![Screenshot 2021-01-26 at 12 37 43](https://user-images.githubusercontent.com/36230812/105846100-9a83d000-5fd3-11eb-994a-4ab18772f336.png)

Valid file name

![Screenshot 2021-01-26 at 12 37 56](https://user-images.githubusercontent.com/36230812/105846092-98ba0c80-5fd3-11eb-9339-d6e334878231.png)
