### PR TITLE
remove type errors on postinstall build

### DIFF
--- a/src/components/DataSourcePicker/DataSourcePicker.tsx
+++ b/src/components/DataSourcePicker/DataSourcePicker.tsx
@@ -95,7 +95,7 @@ export class DataSourcePicker extends PureComponent<Props, State> {
   }
 
   getDataSourceOptions() {
-    const options: any = this.dataSourceSrv.getList().map((ds) => ({
+    const options: Array<SelectableValue<string>> = this.dataSourceSrv.getList().map((ds) => ({
       value: ds.uid,
       label: ds.name,
       imgUrl: ds.meta.info.logos.small,


### PR DESCRIPTION
Prior to this change (without being this specific/explicit with the typings) the following errors were returned

```
src/components/DataSourcePicker/DataSourcePicker.tsx:37:3 - error TS2742: The inferred type of 'dataSourceSrv' cannot be named without a reference to 'ui-enterprise/node_modules/@grafana/runtime'. This is likely not portable. A type annotation is necessary.

37   dataSourceSrv = getDataSourceSrv();
     ~~~~~~~~~~~~~

src/components/DataSourcePicker/DataSourcePicker.tsx:97:3 - error TS2742: The inferred type of 'getDataSourceOptions' cannot be named without a reference to 'ui-enterprise/node_modules/@grafana/data'. This is likely not portable. A type annotation is necessary.

97   getDataSourceOptions() {
     ~~~~~~~~~~~~~~~~~~~~


Found 2 errors.
```

These changes fix those errors