### PR TITLE
feat: support AsyncSelect for selectOption

### DIFF
--- a/src/test/mocks/utils.ts
+++ b/src/test/mocks/utils.ts
@@ -44,7 +44,7 @@ export const selectOption = async (
   optionLabel: string,
   typeOptionLabel?: boolean
 ) => {
-  openSelect(container, typeOptionLabel ? optionLabel : '');
+  openSelect(container, typeOptionLabel ? optionLabel : undefined);
 
   // wait for the list to show
   const option = await waitFor(() => within(container).getByText(optionLabel));


### PR DESCRIPTION
Currently, the existing helper function for selecting an option is not enough for `AsyncSelect` because they don't have any options available until you start typing. This allows you to type the option label so it becomes available and then you can select it.