### PR TITLE
match react version with 8.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.2",
     "@testing-library/user-event": "^12.8.3",
-    "@types/react": "17.0.22",
+    "@types/react": "17.0.38",
     "@types/testing-library__jest-dom": "^5.9.5",
     "babel-loader": "^8.2.2",
     "jest-fetch-mock": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4584,10 +4584,19 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@17.0.22":
+"@types/react@*":
   version "17.0.22"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.22.tgz#c80d1d0e87fe953bae3ab273bef451dea1a6291b"
   integrity sha512-kq/BMeaAVLJM6Pynh8C2rnr/drCK+/5ksH0ch9asz+8FW3DscYCIEFtCeYTFeIx/ubvOsMXmRfy7qEJ76gM96A==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@17.0.38":
+  version "17.0.38"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.38.tgz#f24249fefd89357d5fa71f739a686b8d7c7202bd"
+  integrity sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
Started getting react mismatch [error](https://drone.grafana.net/grafana/splunk-datasource/441/1/5) where a plugin uses this package.

version was added that differs from `8.4.7` [here](https://github.com/grafana/plugin-ui/commit/12f7c5968d0bbafb3efc48b1f99aae9fda35eece#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519)

