### PR TITLE
Extract RunQueryButton component from the QueryHeader

### DIFF
--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -7,7 +7,7 @@ import { ConfirmModal } from './ConfirmModal';
 import { DatasetSelector } from './DatasetSelector';
 import { ErrorBoundary } from './ErrorBoundary';
 import { TableSelector } from './TableSelector';
-import { InlineField, Select, InlineSwitch, Button, Tooltip, RadioButtonGroup } from '@grafana/ui';
+import { InlineField, Select, InlineSwitch, RadioButtonGroup } from '@grafana/ui';
 import { QueryWithDefaults } from './defaults';
 import { EditorField } from './EditorField';
 import { EditorHeader } from './EditorHeader';
@@ -15,6 +15,7 @@ import { EditorRow } from './EditorRow';
 import { FlexItem } from './FlexItem';
 import { InlineSelect } from './InlineSelect';
 import { Space } from './Space';
+import {RunQueryButton} from './RunQueryButton'
 import { DB, SQLQuery, QueryRowFilter, EditorMode, QueryFormat, QUERY_FORMAT_OPTIONS } from './types';
 import { defaultToRawSql } from './utils/sql.utils';
 
@@ -175,26 +176,10 @@ export function QueryHeader({
 
         <FlexItem grow={1} />
 
-        {isQueryRunnable ? (
-          <Button icon="play" variant="primary" size="sm" onClick={() => onRunQuery()}>
-            Run query
-          </Button>
-        ) : (
-          <Tooltip
-            theme="error"
-            content={
-              <>
-                Your query is invalid. Check below for details. <br />
-                However, you can still run this query.
-              </>
-            }
-            placement="top"
-          >
-            <Button icon="exclamation-triangle" variant="secondary" size="sm" onClick={() => onRunQuery()}>
-              Run query
-            </Button>
-          </Tooltip>
-        )}
+        <RunQueryButton
+          queryInvalid={isQueryRunnable}
+          onClick={() => onRunQuery()}
+        />
 
         <RadioButtonGroup options={editorModes} size="sm" value={editorMode} onChange={onEditorModeChange} />
 

--- a/src/components/QueryEditor/RunQueryButton.tsx
+++ b/src/components/QueryEditor/RunQueryButton.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Button, IconName, PopoverContent, Tooltip } from "@grafana/ui";
+
+type RunQueryButtonProps = {
+  ariaLabel?: string;
+  queryInvalid?: boolean;
+  invalidQueryTooltip?: PopoverContent;
+  disabled?: boolean;
+  queryRunning?: boolean;
+  onClick: () => void;
+  dataTestId?: string;
+};
+
+export const RunQueryButton: React.FC<RunQueryButtonProps> = ({
+  ariaLabel = "Query editor Run button",
+  queryRunning = false,
+  queryInvalid = false,
+  invalidQueryTooltip,
+  disabled = false,
+  onClick,
+  dataTestId,
+}) => {
+  let icon: IconName | undefined = queryInvalid
+    ? "exclamation-triangle"
+    : undefined;
+  if (queryRunning) {
+    icon = "fa fa-spinner";
+  }
+
+  const RunButton = (
+    <Button
+      aria-label={ariaLabel}
+      size="sm"
+      variant="secondary"
+      icon={icon}
+      disabled={disabled || queryRunning}
+      onClick={onClick}
+      data-testid={dataTestId ?? false}
+    >
+      Run query
+    </Button>
+  );
+
+  return queryInvalid ? (
+    <Tooltip
+      theme="error"
+      placement="top"
+      content={
+        invalidQueryTooltip ?? (
+          <>
+            Your query is invalid. Check below for details. <br />
+            However, you can still run this query.
+          </>
+        )
+      }
+    >
+      {RunButton}
+    </Tooltip>
+  ) : (
+    RunButton
+  );
+};


### PR DESCRIPTION
Added run query button component like the one on this screen recording:

https://user-images.githubusercontent.com/1436174/227919287-73a4d88b-4bd4-4611-b3e2-b6b1d7203a54.mov

Previously the button in QueryHeader was the primary one with the "play" icon. I removed the icon and made it secondary based on [this discussion](https://github.com/grafana/jira-datasource/pull/149#discussion_r1144707420).
