### PR TITLE
feat: make run query button available (forgot to export it earlier)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-ui",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "repository": "git@github.com:grafana/plugin-ui.git",
   "author": "Grafana Labs",
   "main": "dist/index.js",

--- a/src/components/QueryEditor/index.ts
+++ b/src/components/QueryEditor/index.ts
@@ -14,5 +14,6 @@ export { InlineSelect } from './InlineSelect';
 export { InputGroup } from './InputGroup';
 export { Space } from './Space';
 export { SqlQueryEditor } from './QueryEditor';
+export { RunQueryButton } from './RunQueryButton';
 
 export * from './types';


### PR DESCRIPTION
Forgot to export the run query button component, so it wasn't possible to import it in the previous release.