### PR TITLE
fix: Prevent rendering data-testid="false" in RunQueryButton

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-ui",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "repository": "git@github.com:grafana/plugin-ui.git",
   "author": "Grafana Labs",
   "main": "dist/index.js",

--- a/src/components/QueryEditor/RunQueryButton.tsx
+++ b/src/components/QueryEditor/RunQueryButton.tsx
@@ -35,7 +35,7 @@ export const RunQueryButton: React.FC<RunQueryButtonProps> = ({
       icon={icon}
       disabled={disabled || queryRunning}
       onClick={onClick}
-      data-testid={dataTestId ?? false}
+      data-testid={dataTestId}
     >
       Run query
     </Button>


### PR DESCRIPTION
When `dataTestId` wasn't passed it was rendered as `data-testid="false"`.

Before:
<img width="381" alt="image" src="https://user-images.githubusercontent.com/1436174/228054561-b23d2b61-0620-4e57-a716-3b368862b2c4.png">

After:
<img width="381" alt="image" src="https://user-images.githubusercontent.com/1436174/228054732-07e651cb-8dc1-4293-9926-00fd7133c1c2.png">