### PR TITLE
fix: Prevent DatePickerWithInput styles to pollute global styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-ui",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "repository": "git@github.com:grafana/plugin-ui.git",
   "author": "Grafana Labs",
   "main": "dist/index.js",

--- a/src/components/DatePickerWithInput/DatePickerWithInput.tsx
+++ b/src/components/DatePickerWithInput/DatePickerWithInput.tsx
@@ -13,9 +13,13 @@ export interface DatePickerWithInputProps
 }
 
 export const DatePickerWithInput = (props: DatePickerWithInputProps) => {
-  const { value, onChange, ...rest } = props;
-
+  const { value, onChange, className, ...rest } = props;
   const [open, setOpen] = React.useState(false);
+
+  let inputClassName = 'grafana-plugin-ui-date-input'
+  if (className) {
+    inputClassName += ` ${className}`;
+  }
 
   return (
     <>
@@ -25,6 +29,7 @@ export const DatePickerWithInput = (props: DatePickerWithInputProps) => {
         value={formatDate(value || new Date())}
         onClick={() => setOpen(true)}
         onChange={() => {}}
+        className={inputClassName}
         {...rest}
       />
       <DatePicker

--- a/src/components/DatePickerWithInput/style.css
+++ b/src/components/DatePickerWithInput/style.css
@@ -1,6 +1,8 @@
 /* hides the native Calendar picker icon given when using type=date */
-input[type='date']::-webkit-inner-spin-button,
-input[type='date']::-webkit-calendar-picker-indicator {
+.grafana-plugin-ui-date-input input[type='date']::-webkit-inner-spin-button,
+.grafana-plugin-ui-date-input input[type='date']::-webkit-calendar-picker-indicator,
+input.grafana-plugin-ui-date-input[type='date']::-webkit-inner-spin-button,
+input.grafana-plugin-ui-date-input[type='date']::-webkit-calendar-picker-indicator {
   display: none;
   -webkit-appearance: none;
 }


### PR DESCRIPTION
Datepicker input styles impact all date inputs on the page. This PR fixes it.

Related escalation: https://github.com/grafana/support-escalations/issues/5421