### PR TITLE
Cleanup styling of the DataLinks component to match the redesigned config page

### DIFF
--- a/src/components/DataLinks/DataLinks.tsx
+++ b/src/components/DataLinks/DataLinks.tsx
@@ -11,8 +11,9 @@ import { DataLink } from './DataLink';
 
 const getStyles = ((theme: GrafanaTheme2) => ({
   infoText: css`
-    padding-bottom: ${theme.v1.spacing.md};
-    color: ${theme.v1.colors.textWeak};
+    font-size: ${theme.typography.bodySmall.fontSize};
+    color: ${theme.colors.text.secondary};
+    margin-bottom: ${theme.v1.spacing.md};
   `,
   dataLink: css`
     margin-bottom: ${theme.v1.spacing.sm};
@@ -30,7 +31,7 @@ export const DataLinks = (props: Props) => {
 
   return (
     <>
-      <h3 className='page-heading'>Data links</h3>
+      <h3>Data links</h3>
 
       <div className={styles.infoText}>
         Add links to existing fields. Links will be shown in log row details


### PR DESCRIPTION
For now changed the font sizes and spacing, but probably more to come so leaving this as a draft for now.

@josiahg What should we use instead of `meaningful label` in tooltip

@catherineymgui  Was there a final decision on the widths of the fields yet ?

<img width="1768" alt="Screenshot 2023-04-17 at 12 21 39" src="https://user-images.githubusercontent.com/112862936/232458354-96b76d45-81b5-4d26-a303-c4122f1a2137.png">
