### PR TITLE
fix: export recently added unreleased components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-ui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "repository": "git@github.com:grafana/plugin-ui.git",
   "author": "Grafana Labs",
   "main": "dist/index.js",

--- a/src/unreleasedComponents/index.ts
+++ b/src/unreleasedComponents/index.ts
@@ -1,2 +1,3 @@
 // noop for when there are no components here
-export {};
+export { SecretInput } from "./SecretInput";
+export { SecretTextArea } from "./SecretTextarea";


### PR DESCRIPTION
Missed exporting these in the [previous PR](https://github.com/grafana/plugin-ui/pull/71)