### PR TITLE
feat: add changelog functions to avoid commit hash in release lines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-ui",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "repository": "git@github.com:grafana/plugin-ui.git",
   "author": "Grafana Labs",
   "main": "dist/index.js",

--- a/src/utils/changeset/functions.ts
+++ b/src/utils/changeset/functions.ts
@@ -1,0 +1,17 @@
+import {
+  GetReleaseLine,
+  GetDependencyReleaseLine,
+  ChangelogFunctions,
+} from "@changesets/types";
+
+const getReleaseLine: GetReleaseLine = async (changeset) =>
+  `- ${changeset.summary}`;
+
+const getDependencyReleaseLine: GetDependencyReleaseLine = async () => "";
+
+const defaultChangelogFunctions: ChangelogFunctions = {
+  getReleaseLine,
+  getDependencyReleaseLine,
+};
+
+export default defaultChangelogFunctions;


### PR DESCRIPTION
Currently we started to use `@changesets/cli/changelog` package to generate release lines and that adds commit hashes also. But for enterprise plugins source code is not public and commit hashes don't make sense in the changelog. So adding custom functions according to [this guide](https://github.com/changesets/changesets/blob/main/docs/modifying-changelog-format.md) so that we can use it to add only change summary to the changelog.

| Before | After |
|--------|--------|
| ![image](https://github.com/grafana/plugin-ui/assets/1436174/1eec8423-c8e3-47db-b181-36dd360bfccb) | ![image](https://github.com/grafana/plugin-ui/assets/1436174/aa26f690-6497-4563-bab2-a2b3676c10d8) | 