### PR TITLE
Secure Socks Proxy: Add UI toggle to plugin-ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "@grafana/plugin-ui",
+  "version": "0.3.4",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "react-use": "17.3.1",
     "react-virtualized-auto-sizer": "^1.0.6",
     "semver": "^7.3.5",
-    "sql-formatter-plus": "^1.3.6",
-    "typescript": "^4.7.4"
+    "sql-formatter-plus": "^1.3.6"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",
@@ -64,7 +63,8 @@
     "babel-loader": "^8.2.2",
     "jest-fetch-mock": "^3.0.3",
     "mockdate": "^3.0.2",
-    "ts-jest": "^26.4.4"
+    "ts-jest": "^26.4.4",
+    "typescript": "^4.9.5"
   },
   "peerDependencies": {
     "@changesets/cli": ">=2.x"

--- a/src/components/ConfigEditor/SecureSocksProxyToggle.test.tsx
+++ b/src/components/ConfigEditor/SecureSocksProxyToggle.test.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { SecureSocksProxyToggle } from "./SecureSocksProxyToggle";
+import  * as compat  from "../../utils/compatibility";
+import { config } from "@grafana/runtime";
+
+describe("<SecureSocksProxyToggle />", () => {
+  const dataSourceConfig = {
+    id: 4,
+    uid: "x",
+    orgId: 1,
+    name: "gdev-influxdb",
+    type: "influxdb",
+    typeName: "Influxdb",
+    typeLogoUrl: "",
+    access: "direct",
+    url: "http://localhost:8086",
+    password: "",
+    user: "grafana",
+    database: "site",
+    basicAuth: false,
+    basicAuthUser: "",
+    basicAuthPassword: "",
+    withCredentials: false,
+    isDefault: false,
+    jsonData: {
+      enableSecureSocksProxy: false,
+    },
+    secureJsonData: {
+      password: true,
+    },
+    secureJsonFields: {},
+    readOnly: true,
+  };
+
+  const labelWidth = 10;
+
+  const onChange = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should not render when compatibility check fails", () => {
+    jest.spyOn(compat, "hasCompatibility").mockReturnValue(false);
+
+    const { container } = render(
+      <SecureSocksProxyToggle
+        dataSourceConfig={dataSourceConfig}
+        onChange={onChange}
+        labelWidth={labelWidth}
+      />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should not render when secureSocksDSProxyEnabled is disabled in config", () => {
+    jest.spyOn(compat, "hasCompatibility").mockReturnValue(true);
+    jest.spyOn(config as any, "secureSocksDSProxyEnabled").mockReturnValue(false);
+
+    const { container } = render(
+      <SecureSocksProxyToggle
+        dataSourceConfig={dataSourceConfig}
+        onChange={onChange}
+        labelWidth={labelWidth}
+      />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should render and switch json data when enabled in config", () => {
+    jest.spyOn(compat, "hasCompatibility").mockReturnValue(true);
+    jest.spyOn(config as any, "secureSocksDSProxyEnabled").mockReturnValue(true);
+
+    const { getByLabelText } = render(
+      <SecureSocksProxyToggle
+        dataSourceConfig={dataSourceConfig}
+        onChange={onChange}
+        labelWidth={labelWidth}
+      />
+    );
+
+    const switchElement = getByLabelText("Secure Socks Proxy Enabled") as HTMLInputElement;
+    expect(switchElement).toBeInTheDocument();
+    expect(switchElement.checked).toBe(false);
+
+    fireEvent.click(switchElement);
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...dataSourceConfig,
+      jsonData: {
+        ...dataSourceConfig.jsonData,
+        enableSecureSocksProxy: true,
+      },
+    });
+  });
+});

--- a/src/components/ConfigEditor/SecureSocksProxyToggle.tsx
+++ b/src/components/ConfigEditor/SecureSocksProxyToggle.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { InlineLabel as OriginalInlineLabel,InlineField,InlineSwitch } from "@grafana/ui";
+import { config } from "@grafana/runtime";
+import { DataSourceSettings } from "@grafana/data";
+import { hasCompatibility, CompatibilityFeature } from "../../utils/compatibility";
+
+type Props = Omit<React.ComponentProps<typeof OriginalInlineLabel>, 'children'> & {
+  dataSourceConfig: DataSourceSettings<any, any>;
+  onChange: (config: DataSourceSettings) => void;
+  labelWidth: number;
+};
+
+export const SecureSocksProxyToggle: React.FC<Props> = ({
+  labelWidth=10,
+  ...props
+}) => {
+  const { dataSourceConfig, onChange } = props;
+  const handleSwitchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange({
+      ...dataSourceConfig,
+      jsonData: {
+        ...dataSourceConfig.jsonData,
+        enableSecureSocksProxy: e.target.checked,
+      },
+    });
+  };
+
+  return (
+      /* if the compatibility check returns true, secureSocksDSProxyEnabled will be an option in the Grafana config */
+      hasCompatibility(CompatibilityFeature.SECURE_SOCKS_PROXY) && (config as any).secureSocksDSProxyEnabled 
+      &&
+      (
+      <div>
+        <div className="gf-form">
+          <div className="gf-form gf-form-inline">
+            <InlineField
+              label="Secure Socks Proxy Enabled"
+              labelWidth={labelWidth}
+              tooltip={
+                <>
+                  Proxy the datasource connection through the secure socks proxy to a different network. To learn more about configuring the datasource connection proxy, {' '}
+                  <a
+                    href="https://grafana.com/docs/grafana/next/setup-grafana/configure-grafana/proxy/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  > 
+                    click here.
+                  </a>
+                </>
+              }
+            >
+            <InlineSwitch
+              value={dataSourceConfig.jsonData.enableSecureSocksProxy}
+              onChange={handleSwitchChange}
+            />
+            </InlineField>
+          </div>
+        </div>
+        </div>
+      )
+  );
+};

--- a/src/components/ConfigEditor/index.ts
+++ b/src/components/ConfigEditor/index.ts
@@ -1,1 +1,2 @@
 export { InlineLabel } from "./InlineLabel";
+export { SecureSocksProxyToggle } from "./SecureSocksProxyToggle";

--- a/src/utils/compatibility.test.ts
+++ b/src/utils/compatibility.test.ts
@@ -20,5 +20,17 @@ describe("hasCompatibility", () => {
 
     expect(hasCompatibility(CompatibilityFeature.HEALTH_DIAGNOSTICS_ERRORS)).toBeFalsy()
   })
+
+  it("returns true for SECURE_SOCKS_PROXY if the version is supported", () => {
+    jest.spyOn(semver, "gte").mockReturnValue(true)
+
+    expect(hasCompatibility(CompatibilityFeature.SECURE_SOCKS_PROXY)).toBeTruthy()
+  })
+
+  it("returns false for SECURE_SOCKS_PROXY if the version is not supported", () => {
+    jest.spyOn(semver, "gte").mockReturnValue(false)
+
+    expect(hasCompatibility(CompatibilityFeature.SECURE_SOCKS_PROXY)).toBeFalsy()
+  })
 })
 

--- a/src/utils/compatibility.ts
+++ b/src/utils/compatibility.ts
@@ -2,7 +2,8 @@ import { config } from "@grafana/runtime";
 import { gte } from "semver";
 
 export enum CompatibilityFeature {
-  HEALTH_DIAGNOSTICS_ERRORS
+  HEALTH_DIAGNOSTICS_ERRORS,
+  SECURE_SOCKS_PROXY
 }
 
 /**
@@ -19,6 +20,8 @@ export enum CompatibilityFeature {
   switch (feature) {
     case CompatibilityFeature.HEALTH_DIAGNOSTICS_ERRORS:
       return gte(version, "8.0.0");
+    case CompatibilityFeature.SECURE_SOCKS_PROXY:
+      return gte(version, "10.0.0");
     default:
       return false;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14096,10 +14096,10 @@ typescript@4.4.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
   integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
 
-typescript@^4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@^4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
**Background:**
This PR add a UI toggle that will be used across all plugins as we go through enabling the use of the [secure socks proxy](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/proxy/) to proxy datasource connections. Today, this toggle exists in all core and enterprise datasources, but we want to standardize the UI across all datasources.

The toggle should only appear when the Grafana instance is able to run the proxy and has it set up, i.e:
- The Grafana instance is on at least Grafana 10.0.0
- The instance has the feature enabled through the config.ini (via `secure_socks_datasource_proxy.enabled`). This value is passed to the runtime config [here](https://github.com/grafana/grafana/blob/4217c8057b4877a5a73c297f216bc242a209de76/packages/grafana-runtime/src/config.ts#L72).

**Demo:**
https://github.com/grafana/plugin-ui/assets/14365078/6a906d73-31e9-4e24-8d7a-827c480eb902

The corresponding wavefront code can be viewed here: https://github.com/grafana/wavefront-datasource/pull/141
Note: here the proxy is not set up locally to demonstrate how the backend changes when the proxy is toggled on vs off.