### PR TITLE
move user-event to dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.6.1 - 2024-01-09
+
+- 🐛 **Fix**: moving user_event library from dev-dependencies to dependencies
+
 ## v0.6.0 - 2023-10-25
 
 - ⚙️ **Chore**: **BREAKING**: Remove e2e related functionality

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-use": "17.3.1",
     "react-virtualized-auto-sizer": "^1.0.6",
     "semver": "^7.5.4",
+    "@testing-library/user-event": "^12.8.3",
     "sql-formatter-plus": "^1.3.6"
   },
   "devDependencies": {
@@ -54,7 +55,6 @@
     "@storybook/theming": "^6.5.16",
     "@testing-library/jest-dom": "^5.11.6",
     "@testing-library/react": "^11.2.2",
-    "@testing-library/user-event": "^12.8.3",
     "@types/chance": "^1.1.0",
     "@types/lodash": "^4.14.194",
     "@types/memoize-one": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-ui",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "repository": "git@github.com:grafana/plugin-ui.git",
   "author": "Grafana Labs",
   "main": "dist/index.js",


### PR DESCRIPTION
before it was setup as a dev-dependency however this library is being used on the utils.ts file which can be required in other files.

therefore moving it to the dependencies should fix that dependency resolution conflict on other places we use plugin-ui