### PR TITLE
Db types fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.6.2 - 2024-02-02
+
+- ⚙️ **Chore**: better type checks for DB.labels
+
 ## v0.6.1 - 2024-01-09
 
 - 🐛 **Fix**: moving user_event library from dev-dependencies to dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-ui",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "repository": "git@github.com:grafana/plugin-ui.git",
   "author": "Grafana Labs",
   "main": "dist/index.js",

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -85,7 +85,7 @@ export function SqlQueryEditor({ datasource, query, onChange, onRunQuery, range 
         queryRowFilter={queryRowFilter}
         query={queryWithDefaults}
         isQueryRunnable={isQueryRunnable}
-        labels={datasource.getDB(datasource.id).labels}
+        labels={datasource.getDB(datasource.id)?.labels}
       />
 
       <Space v={0.5} />

--- a/src/components/QueryEditor/types.ts
+++ b/src/components/QueryEditor/types.ts
@@ -145,7 +145,7 @@ export interface DB {
   getSqlCompletionProvider: () => LanguageCompletionProvider;
   toRawSql?: (query: SQLQuery) => string;
   functions: () => Promise<Aggregate[]>;
-  labels: Map<string, string>;
+  labels?: Map<"dataset", string>;
 }
 
 export interface QueryEditorProps {


### PR DESCRIPTION
The DB.labels prop is marked as required even though the actual component that uses it marks it as optional: 

https://github.com/grafana/plugin-ui/blob/main/src/components/QueryEditor/QueryHeader.tsx#L46

This PR makes the key optional while also providing better type check for the expected map shape from QueryHeader:

https://github.com/grafana/plugin-ui/blob/main/src/components/QueryEditor/QueryHeader.tsx#L214