### PR TITLE
sql: all dataset selection to be disabled

### DIFF
--- a/src/components/QueryEditor/DatasetSelector.tsx
+++ b/src/components/QueryEditor/DatasetSelector.tsx
@@ -8,6 +8,7 @@ import { DB, ResourceSelectorProps, toOption } from './types';
 
 interface DatasetSelectorProps extends ResourceSelectorProps {
   db: DB;
+  dataset: string;
   value: string | null;
   applyDefault?: boolean;
   disabled?: boolean;
@@ -16,6 +17,7 @@ interface DatasetSelectorProps extends ResourceSelectorProps {
 
 export const DatasetSelector: React.FC<DatasetSelectorProps> = ({
   db,
+  dataset,
   value,
   onChange,
   disabled,
@@ -23,6 +25,11 @@ export const DatasetSelector: React.FC<DatasetSelectorProps> = ({
   applyDefault,
 }) => {
   const state = useAsync(async () => {
+    if (dataset) {
+      onChange(toOption(dataset));
+      return [toOption(dataset)];
+    }
+
     const datasets = await db.datasets();
     return datasets.map(toOption);
   }, []);

--- a/src/components/QueryEditor/InlineSelect.tsx
+++ b/src/components/QueryEditor/InlineSelect.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { GroupBase } from 'react-select';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { SelectCommonProps, SelectContainerProps, stylesFactory, useTheme2,  SelectContainer as BaseSelectContainer } from '@grafana/ui';
+import { Select, SelectCommonProps, SelectContainerProps, stylesFactory, useTheme2,  SelectContainer as BaseSelectContainer } from '@grafana/ui';
 
 interface InlineSelectProps<T> extends SelectCommonProps<T> {
   label?: string;
@@ -27,7 +27,6 @@ export function InlineSelect<T>({ label: labelProp, ...props }: InlineSelectProp
           {':'}&nbsp;
         </label>
       )}
-      {/* @ts-ignore */}
       <Select openMenuOnFocus inputId={id} {...props} components={components} />
     </div>
   );

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -14,11 +14,15 @@ import { VisualEditor } from './visual-query-builder/VisualEditor';
 import { SqlDatasource } from '../../datasource/SqlDatasource';
 import { Space } from './Space';
 
-type Props = QueryEditorProps<SqlDatasource, SQLQuery, SQLOptions>;
+interface Props extends QueryEditorProps<SqlDatasource, SQLQuery, SQLOptions> {
+  disableDatasets?: boolean;
+}
 
-export function SqlQueryEditor({ datasource, query, onChange, onRunQuery, range }: Props) {
+export function SqlQueryEditor({ datasource, query, onChange, onRunQuery, range, disableDatasets = false }: Props) {
   const [isQueryRunnable, setIsQueryRunnable] = useState(true);
   const db = datasource.getDB();
+  const defaultDataset = datasource.dataset;
+
   const { loading, error } = useAsync(async () => {
     return () => {
       if (datasource.getDB(datasource.id).init !== undefined) {
@@ -79,6 +83,8 @@ export function SqlQueryEditor({ datasource, query, onChange, onRunQuery, range 
     <>
       <QueryHeader
         db={db}
+        defaultDataset={defaultDataset || ''}
+        disableDatasets={disableDatasets}
         onChange={onQueryHeaderChange}
         onRunQuery={onRunQuery}
         onQueryRowChange={setQueryRowFilter}

--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -21,6 +21,8 @@ import { defaultToRawSql } from './utils/sql.utils';
 
 interface QueryHeaderProps {
   db: DB;
+  defaultDataset: string;
+  disableDatasets: boolean;
   query: QueryWithDefaults;
   onChange: (query: SQLQuery) => void;
   onRunQuery: () => void;
@@ -37,6 +39,8 @@ const editorModes = [
 
 export function QueryHeader({
   db,
+  defaultDataset,
+  disableDatasets,
   query,
   queryRowFilter,
   onChange,
@@ -211,17 +215,21 @@ export function QueryHeader({
           <Space v={0.5} />
 
           <EditorRow>
-            <EditorField label={labels.get('dataset') || 'Dataset'} width={25}>
-              <DatasetSelector
-                db={db}
-                value={query.dataset === undefined ? null : query.dataset}
-                onChange={onDatasetChange}
-              />
-            </EditorField>
+            {disableDatasets === false && (
+              <EditorField label={labels.get('dataset') || 'Dataset'} width={25}>
+                <DatasetSelector
+                  db={db}
+                  dataset={defaultDataset}
+                  value={query.dataset === undefined ? null : query.dataset}
+                  onChange={onDatasetChange}
+                />
+              </EditorField>
+            )}
 
             <EditorField label="Table" width={25}>
               <TableSelector
                 db={db}
+                dataset={query.dataset || defaultDataset}
                 query={query}
                 value={query.table === undefined ? null : query.table}
                 onChange={onTableChange}

--- a/src/components/QueryEditor/TableSelector.tsx
+++ b/src/components/QueryEditor/TableSelector.tsx
@@ -8,19 +8,21 @@ import { QueryWithDefaults } from './defaults';
 
 interface TableSelectorProps extends ResourceSelectorProps {
   db: DB;
+  dataset: string;
   value: string | null;
   query: QueryWithDefaults;
   onChange: (v: SelectableValue) => void;
 }
 
-export const TableSelector: React.FC<TableSelectorProps> = ({ db, query, value, className, onChange }) => {
+export const TableSelector: React.FC<TableSelectorProps> = ({ db, dataset, value, className, onChange }) => {
   const state = useAsync(async () => {
-    if (!query.dataset) {
+    if (!dataset) {
       return [];
     }
-    const tables = await db.tables(query.dataset);
+
+    const tables = await db.tables(dataset)
     return tables.map(toOption);
-  }, [query.dataset]);
+  }, [dataset]);
 
   return (
     <Select

--- a/src/datasource/SqlDatasource.ts
+++ b/src/datasource/SqlDatasource.ts
@@ -54,6 +54,7 @@ export abstract class SqlDatasource extends DataSourceWithBackend<SQLQuery, SQLO
   name: string;
   interval: string;
   db: DB;
+  dataset?: string;
   annotations = {};
 
   constructor(


### PR DESCRIPTION
in postgres-based datasources we don't use datasets. this pr allows datasources to decide if they want to use datasets.

if datasets are disabled, it will use `datasource.dataset` as the database.