### PR TITLE
improved way of disable datasets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-ui",
-  "version": "0.6.4",
+  "version": "0.7.1",
   "repository": "git@github.com:grafana/plugin-ui.git",
   "author": "Grafana Labs",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-ui",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "repository": "git@github.com:grafana/plugin-ui.git",
   "author": "Grafana Labs",
   "main": "dist/index.js",

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -14,11 +14,9 @@ import { VisualEditor } from './visual-query-builder/VisualEditor';
 import { SqlDatasource } from '../../datasource/SqlDatasource';
 import { Space } from './Space';
 
-interface Props extends QueryEditorProps<SqlDatasource, SQLQuery, SQLOptions> {
-  enableDatasets?: boolean;
-}
+interface Props extends QueryEditorProps<SqlDatasource, SQLQuery, SQLOptions> {}
 
-export function SqlQueryEditor({ datasource, query, onChange, onRunQuery, range, enableDatasets = true }: Props) {
+export function SqlQueryEditor({ datasource, query, onChange, onRunQuery, range }: Props) {
   const [isQueryRunnable, setIsQueryRunnable] = useState(true);
   const db = datasource.getDB();
   const defaultDataset = datasource.dataset;
@@ -84,7 +82,7 @@ export function SqlQueryEditor({ datasource, query, onChange, onRunQuery, range,
       <QueryHeader
         db={db}
         defaultDataset={defaultDataset || ''}
-        enableDatasets={enableDatasets}
+        enableDatasets={db.disableDatasets === true ? false : true}
         onChange={onQueryHeaderChange}
         onRunQuery={onRunQuery}
         onQueryRowChange={setQueryRowFilter}

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -82,7 +82,7 @@ export function SqlQueryEditor({ datasource, query, onChange, onRunQuery, range 
       <QueryHeader
         db={db}
         defaultDataset={defaultDataset || ''}
-        enableDatasets={db.disableDatasets === true ? false : true}
+        enableDatasets={!db.disableDatasets}
         onChange={onQueryHeaderChange}
         onRunQuery={onRunQuery}
         onQueryRowChange={setQueryRowFilter}

--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -17,7 +17,7 @@ import { InlineSelect } from './InlineSelect';
 import { Space } from './Space';
 import {RunQueryButton} from './RunQueryButton'
 import { DB, SQLQuery, QueryRowFilter, EditorMode, QueryFormat, QUERY_FORMAT_OPTIONS } from './types';
-import { defaultToRawSql } from './utils/sql.utils';
+import { getRawSqlFN } from './utils/sql.utils';
 
 interface QueryHeaderProps {
   db: DB;
@@ -52,7 +52,7 @@ export function QueryHeader({
   const { editorMode } = query;
   const [_, copyToClipboard] = useCopyToClipboard();
   const [showConfirm, setShowConfirm] = useState(false);
-  const toRawSql = db.toRawSql || defaultToRawSql;
+  const toRawSql = getRawSqlFN(db);
 
   const onEditorModeChange = useCallback(
     (newEditorMode: EditorMode) => {

--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -17,7 +17,7 @@ import { InlineSelect } from './InlineSelect';
 import { Space } from './Space';
 import {RunQueryButton} from './RunQueryButton'
 import { DB, SQLQuery, QueryRowFilter, EditorMode, QueryFormat, QUERY_FORMAT_OPTIONS } from './types';
-import { getRawSqlFN } from './utils/sql.utils';
+import { getRawSqlFn } from './utils/sql.utils';
 
 interface QueryHeaderProps {
   db: DB;
@@ -52,7 +52,7 @@ export function QueryHeader({
   const { editorMode } = query;
   const [_, copyToClipboard] = useCopyToClipboard();
   const [showConfirm, setShowConfirm] = useState(false);
-  const toRawSql = getRawSqlFN(db);
+  const toRawSql = getRawSqlFn(db);
 
   const onEditorModeChange = useCallback(
     (newEditorMode: EditorMode) => {

--- a/src/components/QueryEditor/types.ts
+++ b/src/components/QueryEditor/types.ts
@@ -146,6 +146,7 @@ export interface DB {
   toRawSql?: (query: SQLQuery) => string;
   functions: () => Promise<Aggregate[]>;
   labels?: Map<"dataset", string>;
+  disableDatasets?: boolean;
 }
 
 export interface QueryEditorProps {

--- a/src/components/QueryEditor/utils/sql.utils.ts
+++ b/src/components/QueryEditor/utils/sql.utils.ts
@@ -22,7 +22,7 @@ export function toRawSql({ sql, dataset, table }: SQLQuery, disableDatasets: boo
 
   rawQuery += createSelectClause(sql.columns);
 
-  if (disableDatasets === true) {
+  if (disableDatasets) {
     if (table) {
       rawQuery += `FROM ${table} `;
     }

--- a/src/components/QueryEditor/utils/sql.utils.ts
+++ b/src/components/QueryEditor/utils/sql.utils.ts
@@ -9,7 +9,7 @@ import {
 } from '../expressions';
 import { SQLQuery, SQLExpression, DB } from '../types';
 
-export function getRawSqlFN(db: DB) {
+export function getRawSqlFn(db: DB) {
   if (db.toRawSql) {
     return db.toRawSql;
   }

--- a/src/components/QueryEditor/utils/sql.utils.ts
+++ b/src/components/QueryEditor/utils/sql.utils.ts
@@ -7,12 +7,23 @@ import {
   QueryEditorPropertyExpression,
   QueryEditorPropertyType,
 } from '../expressions';
-import { SQLQuery, SQLExpression } from '../types';
+import { SQLQuery, SQLExpression, DB } from '../types';
 
-export function defaultToRawSql({ sql, dataset, table }: SQLQuery): string {
+export function getRawSqlFN(db: DB) {
+  if (db.toRawSql) {
+    return db.toRawSql;
+  }
+
+  if (db.disableDatasets) {
+    return toRawSqlWithoutDataset;
+  }
+
+  return toRawSql;
+}
+
+export function toRawSql({ sql, dataset, table }: SQLQuery): string {
   let rawQuery = '';
 
-  // Return early with empty string if there is no sql column
   if (!sql || !haveColumns(sql.columns)) {
     return rawQuery;
   }
@@ -40,7 +51,42 @@ export function defaultToRawSql({ sql, dataset, table }: SQLQuery): string {
     rawQuery += `${sql.orderByDirection} `;
   }
 
-  // Altough LIMIT 0 doesn't make sense, it is still possible to have LIMIT 0
+  if (sql.limit !== undefined && sql.limit >= 0) {
+    rawQuery += `LIMIT ${sql.limit} `;
+  }
+  return rawQuery;
+}
+
+export function toRawSqlWithoutDataset({ sql, table }: SQLQuery): string {
+  let rawQuery = '';
+
+  if (!sql || !haveColumns(sql.columns)) {
+    return rawQuery;
+  }
+
+  rawQuery += createSelectClause(sql.columns);
+
+  if (table) {
+    rawQuery += `FROM ${table} `;
+  }
+
+  if (sql.whereString) {
+    rawQuery += `WHERE ${sql.whereString} `;
+  }
+
+  if (sql.groupBy?.[0]?.property.name) {
+    const groupBy = sql.groupBy.map((g) => g.property.name).filter((g) => !isEmpty(g));
+    rawQuery += `GROUP BY ${groupBy.join(', ')} `;
+  }
+
+  if (sql.orderBy?.property.name) {
+    rawQuery += `ORDER BY ${sql.orderBy.property.name} `;
+  }
+
+  if (sql.orderBy?.property.name && sql.orderByDirection) {
+    rawQuery += `${sql.orderByDirection} `;
+  }
+
   if (sql.limit !== undefined && sql.limit >= 0) {
     rawQuery += `LIMIT ${sql.limit} `;
   }
@@ -60,7 +106,7 @@ function createSelectClause(sqlColumns: NonNullable<SQLExpression['columns']>): 
   return `SELECT ${columns.join(', ')} `;
 }
 
-export const haveColumns = (columns: SQLExpression['columns']): columns is NonNullable<SQLExpression['columns']> => {
+export function haveColumns(columns: SQLExpression['columns']): columns is NonNullable<SQLExpression['columns']> {
   if (!columns) {
     return false;
   }
@@ -68,7 +114,7 @@ export const haveColumns = (columns: SQLExpression['columns']): columns is NonNu
   const haveColumn = columns.some((c) => c.parameters?.length || c.parameters?.some((p) => p.name));
   const haveFunction = columns.some((c) => c.name);
   return haveColumn || haveFunction;
-};
+}
 
 /**
  * Creates a GroupByExpression for a specified field

--- a/src/components/QueryEditor/utils/useSqlChange.ts
+++ b/src/components/QueryEditor/utils/useSqlChange.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 
 import { DB, SQLExpression, SQLQuery } from '../types';
 
-import { defaultToRawSql } from './sql.utils';
+import { getRawSqlFN } from './sql.utils';
 
 interface UseSqlChange {
   db: DB;
@@ -13,7 +13,7 @@ interface UseSqlChange {
 export function useSqlChange({ query, onQueryChange, db }: UseSqlChange) {
   const onSqlChange = useCallback(
     (sql: SQLExpression) => {
-      const toRawSql = db.toRawSql || defaultToRawSql;
+      const toRawSql = getRawSqlFN(db);
       const rawSql = toRawSql({ sql, dataset: query.dataset, table: query.table, refId: query.refId });
       const newQuery: SQLQuery = { ...query, sql, rawSql };
       onQueryChange(newQuery);

--- a/src/components/QueryEditor/utils/useSqlChange.ts
+++ b/src/components/QueryEditor/utils/useSqlChange.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 
 import { DB, SQLExpression, SQLQuery } from '../types';
 
-import { getRawSqlFN } from './sql.utils';
+import { getRawSqlFn } from './sql.utils';
 
 interface UseSqlChange {
   db: DB;
@@ -13,7 +13,7 @@ interface UseSqlChange {
 export function useSqlChange({ query, onQueryChange, db }: UseSqlChange) {
   const onSqlChange = useCallback(
     (sql: SQLExpression) => {
-      const toRawSql = getRawSqlFN(db);
+      const toRawSql = getRawSqlFn(db);
       const rawSql = toRawSql({ sql, dataset: query.dataset, table: query.table, refId: query.refId });
       const newQuery: SQLQuery = { ...query, sql, rawSql };
       onQueryChange(newQuery);


### PR DESCRIPTION
currently if you want to disable datasets you need to do the following:
1. pass the `enableDatasets = false` prop into SqlQueryEditor.
2. provide a custom `toRawSql` function, that doesn't expect a dataset

this pr removes the need for code duplication in all datasources with disabled datasets by no longer requiring a custom `toRawSql` function.

this pr also also changes where you declare `disableDatasets`, this is now declared in datasource.ts opposed to previously this was just a prop in the builder component.

---

after this pr is merged, the only thing you need to do is add the flag `disableDatasets: true` to the getDB function inside of `datasource.ts`.
```ts
getDB(): DB {
  return {
    {... your other database options}
    disableDatasets: true, // <---- just add this line here
  };
}
```