### PR TITLE
Query format enum

### DIFF
--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -1,23 +1,35 @@
-import React, { useCallback, useState } from 'react';
-import { useCopyToClipboard } from 'react-use';
+import React, { useCallback, useState } from "react";
+import { useCopyToClipboard } from "react-use";
 
-import { SelectableValue } from '@grafana/data';
+import { SelectableValue } from "@grafana/data";
 
-import { ConfirmModal } from './ConfirmModal';
-import { DatasetSelector } from './DatasetSelector';
-import { ErrorBoundary } from './ErrorBoundary';
-import { TableSelector } from './TableSelector';
-import { InlineField, Select, InlineSwitch, RadioButtonGroup } from '@grafana/ui';
-import { QueryWithDefaults } from './defaults';
-import { EditorField } from './EditorField';
-import { EditorHeader } from './EditorHeader';
-import { EditorRow } from './EditorRow';
-import { FlexItem } from './FlexItem';
-import { InlineSelect } from './InlineSelect';
-import { Space } from './Space';
-import {RunQueryButton} from './RunQueryButton'
-import { DB, SQLQuery, QueryRowFilter, EditorMode, QueryFormat, QUERY_FORMAT_OPTIONS } from './types';
-import { defaultToRawSql } from './utils/sql.utils';
+import { ConfirmModal } from "./ConfirmModal";
+import { DatasetSelector } from "./DatasetSelector";
+import { ErrorBoundary } from "./ErrorBoundary";
+import { TableSelector } from "./TableSelector";
+import {
+  InlineField,
+  Select,
+  InlineSwitch,
+  RadioButtonGroup,
+} from "@grafana/ui";
+import { QueryWithDefaults } from "./defaults";
+import { EditorField } from "./EditorField";
+import { EditorHeader } from "./EditorHeader";
+import { EditorRow } from "./EditorRow";
+import { FlexItem } from "./FlexItem";
+import { InlineSelect } from "./InlineSelect";
+import { Space } from "./Space";
+import { RunQueryButton } from "./RunQueryButton";
+import {
+  DB,
+  SQLQuery,
+  QueryRowFilter,
+  EditorMode,
+  QueryFormat,
+  QUERY_FORMAT_OPTIONS,
+} from "./types";
+import { defaultToRawSql } from "./utils/sql.utils";
 
 interface QueryHeaderProps {
   db: DB;
@@ -29,12 +41,13 @@ interface QueryHeaderProps {
   onQueryRowChange: (queryRowFilter: QueryRowFilter) => void;
   queryRowFilter: QueryRowFilter;
   isQueryRunnable: boolean;
-  labels?: Map<string,string>;
+  labels?: Map<string, string>;
+  queryFormatOptions?: SelectableValue[];
 }
 
 const editorModes = [
-  { label: 'Builder', value: EditorMode.Builder },
-  { label: 'Code', value: EditorMode.Code },
+  { label: "Builder", value: EditorMode.Builder },
+  { label: "Code", value: EditorMode.Code },
 ];
 
 export function QueryHeader({
@@ -47,7 +60,8 @@ export function QueryHeader({
   onRunQuery,
   onQueryRowChange,
   isQueryRunnable,
-  labels = new Map([['dataset', 'Dataset']]),
+  labels = new Map([["dataset", "Dataset"]]),
+  queryFormatOptions = QUERY_FORMAT_OPTIONS,
 }: QueryHeaderProps) {
   const { editorMode } = query;
   const [_, copyToClipboard] = useCopyToClipboard();
@@ -66,7 +80,10 @@ export function QueryHeader({
   );
 
   const onFormatChange = (e: SelectableValue) => {
-    const next = { ...query, format: e.value !== undefined ? e.value : QueryFormat.Table };
+    const next = {
+      ...query,
+      format: e.value !== undefined ? e.value : QueryFormat.Table,
+    };
     onChange(next);
   };
 
@@ -80,7 +97,7 @@ export function QueryHeader({
       dataset: e.value,
       table: undefined,
       sql: undefined,
-      rawSql: '',
+      rawSql: "",
     };
 
     onChange(next);
@@ -95,7 +112,7 @@ export function QueryHeader({
       ...query,
       table: e.value,
       sql: undefined,
-      rawSql: '',
+      rawSql: "",
     };
     onChange(next);
   };
@@ -111,7 +128,7 @@ export function QueryHeader({
                 placeholder="Select format"
                 value={query.format}
                 onChange={onFormatChange}
-                options={QUERY_FORMAT_OPTIONS}
+                options={queryFormatOptions}
               />
             </InlineField>
           }
@@ -122,7 +139,7 @@ export function QueryHeader({
             placeholder="Select format"
             menuShouldPortal
             onChange={onFormatChange}
-            options={QUERY_FORMAT_OPTIONS}
+            options={queryFormatOptions}
           />
         </ErrorBoundary>
 
@@ -136,7 +153,10 @@ export function QueryHeader({
               value={queryRowFilter.filter}
               onChange={(ev) =>
                 ev.target instanceof HTMLInputElement &&
-                onQueryRowChange({ ...queryRowFilter, filter: ev.target.checked })
+                onQueryRowChange({
+                  ...queryRowFilter,
+                  filter: ev.target.checked,
+                })
               }
             />
 
@@ -148,7 +168,10 @@ export function QueryHeader({
               value={queryRowFilter.group}
               onChange={(ev) =>
                 ev.target instanceof HTMLInputElement &&
-                onQueryRowChange({ ...queryRowFilter, group: ev.target.checked })
+                onQueryRowChange({
+                  ...queryRowFilter,
+                  group: ev.target.checked,
+                })
               }
             />
 
@@ -160,7 +183,10 @@ export function QueryHeader({
               value={queryRowFilter.order}
               onChange={(ev) =>
                 ev.target instanceof HTMLInputElement &&
-                onQueryRowChange({ ...queryRowFilter, order: ev.target.checked })
+                onQueryRowChange({
+                  ...queryRowFilter,
+                  order: ev.target.checked,
+                })
               }
             />
 
@@ -172,7 +198,10 @@ export function QueryHeader({
               value={queryRowFilter.preview}
               onChange={(ev) =>
                 ev.target instanceof HTMLInputElement &&
-                onQueryRowChange({ ...queryRowFilter, preview: ev.target.checked })
+                onQueryRowChange({
+                  ...queryRowFilter,
+                  preview: ev.target.checked,
+                })
               }
             />
           </>
@@ -185,7 +214,12 @@ export function QueryHeader({
           onClick={() => onRunQuery()}
         />
 
-        <RadioButtonGroup options={editorModes} size="sm" value={editorMode} onChange={onEditorModeChange} />
+        <RadioButtonGroup
+          options={editorModes}
+          size="sm"
+          value={editorMode}
+          onChange={onEditorModeChange}
+        />
 
         <ConfirmModal
           isOpen={showConfirm}
@@ -216,7 +250,10 @@ export function QueryHeader({
 
           <EditorRow>
             {enableDatasets === true && (
-              <EditorField label={labels.get('dataset') || 'Dataset'} width={25}>
+              <EditorField
+                label={labels.get("dataset") || "Dataset"}
+                width={25}
+              >
                 <DatasetSelector
                   db={db}
                   dataset={defaultDataset}

--- a/src/components/QueryEditor/types.ts
+++ b/src/components/QueryEditor/types.ts
@@ -1,22 +1,26 @@
-import { JsonTree } from 'react-awesome-query-builder';
+import { JsonTree } from "react-awesome-query-builder";
 
 import {
   DataFrame,
-  DataQuery,
   DataSourceJsonData,
   MetricFindValue,
   SelectableValue,
   TimeRange,
   toOption as toOptionFromData,
-} from '@grafana/data';
+} from "@grafana/data";
 
-import { QueryWithDefaults } from './defaults';
+import { DataQuery } from "@grafana/schema";
+
+import { QueryWithDefaults } from "./defaults";
 import {
   QueryEditorFunctionExpression,
   QueryEditorGroupByExpression,
   QueryEditorPropertyExpression,
-} from './expressions';
-import { CompletionItemKind, LanguageCompletionProvider } from '@grafana/experimental';
+} from "./expressions";
+import {
+  CompletionItemKind,
+  LanguageCompletionProvider,
+} from "@grafana/experimental";
 
 export interface SqlQueryForInterpolation {
   dataset?: string;
@@ -44,14 +48,16 @@ export interface SQLOptions extends SQLConnectionLimits, DataSourceJsonData {
   timeInterval: string;
 }
 
+// Match the Enums Expected in SqlUtil and SqlDS
+// https://github.com/grafana/grafana-plugin-sdk-go/blob/main/data/sqlutil/query.go#L18-L29
 export enum QueryFormat {
-  Timeseries = 'time_series',
-  Table = 'table',
+  Timeseries,
+  Table,
 }
 
 export enum EditorMode {
-  Builder = 'builder',
-  Code = 'code',
+  Builder = "builder",
+  Code = "code",
 }
 
 export interface SQLQuery extends DataQuery {
@@ -79,7 +85,7 @@ export interface SQLExpression {
   filters?: SQLFilters;
   groupBy?: QueryEditorGroupByExpression[];
   orderBy?: QueryEditorPropertyExpression;
-  orderByDirection?: 'ASC' | 'DESC';
+  orderByDirection?: "ASC" | "DESC";
   limit?: number;
   offset?: number;
 }
@@ -105,8 +111,8 @@ export interface QueryRowFilter {
 }
 
 export const QUERY_FORMAT_OPTIONS = [
-  { label: 'Time series', value: QueryFormat.Timeseries },
-  { label: 'Table', value: QueryFormat.Table },
+  { label: "Time series", value: QueryFormat.Timeseries },
+  { label: "Table", value: QueryFormat.Table },
 ];
 
 const backWardToOption = (value: string) => ({ label: value, value });
@@ -120,7 +126,13 @@ export interface ResourceSelectorProps {
 }
 // React Awesome Query builder field types.
 // These are responsible for rendering the correct UI for the field.
-export type RAQBFieldTypes = 'text' | 'number' | 'boolean' | 'datetime' | 'date' | 'time';
+export type RAQBFieldTypes =
+  | "text"
+  | "number"
+  | "boolean"
+  | "datetime"
+  | "date"
+  | "time";
 
 export interface SQLSelectableValue extends SelectableValue {
   type?: string;
@@ -138,10 +150,15 @@ export interface DB {
   datasets: () => Promise<string[]>;
   tables: (dataset?: string) => Promise<string[]>;
   fields: (query: SQLQuery, order?: boolean) => Promise<SQLSelectableValue[]>;
-  validateQuery: (query: SQLQuery, range?: TimeRange) => Promise<ValidationResults>;
+  validateQuery: (
+    query: SQLQuery,
+    range?: TimeRange
+  ) => Promise<ValidationResults>;
   dsID: () => number;
   dispose?: (dsID?: string) => void;
-  lookup: (path?: string) => Promise<Array<{ name: string; completion: string }>>;
+  lookup: (
+    path?: string
+  ) => Promise<Array<{ name: string; completion: string }>>;
   getSqlCompletionProvider: () => LanguageCompletionProvider;
   toRawSql?: (query: SQLQuery) => string;
   functions: () => Promise<Aggregate[]>;

--- a/src/components/QueryEditor/types.ts
+++ b/src/components/QueryEditor/types.ts
@@ -53,6 +53,9 @@ export interface SQLOptions extends SQLConnectionLimits, DataSourceJsonData {
 export enum QueryFormat {
   Timeseries,
   Table,
+  Logs,
+  Trace,
+  OptiuonMulti,
 }
 
 export enum EditorMode {


### PR DESCRIPTION
Make the QueryFormat enum match the expected enum values from sqlds and sqlutil instead of the current strings.

Makes it easier to use SqlQueryEditor on any `sqlds` based plugin