### PR TITLE
Fix the run query button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-ui",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "repository": "git@github.com:grafana/plugin-ui.git",
   "author": "Grafana Labs",
   "main": "dist/index.js",

--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -181,7 +181,7 @@ export function QueryHeader({
         <FlexItem grow={1} />
 
         <RunQueryButton
-          queryInvalid={isQueryRunnable}
+          queryInvalid={!isQueryRunnable}
           onClick={() => onRunQuery()}
         />
 


### PR DESCRIPTION
at some point this component was changed and this caused a mis-match in the props.
the component expected `queryInvalid` but was actually passed `isQueryRunnable` which is the opposite boolean state.

this caused all error states to be reversed, here is an example in [databricks](https://github.com/grafana/plugins-private/blob/93da006af288067f252c65126278cd3b2b1d75f8/plugins/grafana-databricks-datasource/src/datasource.ts#L109-L114) where this caused a problem.

> @grafana/enterprise-datasources, when this is released, you will need to update the validateQuery function in the databricks ds to be the correct values again.