### PR TITLE
feat: modify `Config` type so `<Auth>` component can be used on plugin  config pages

### DIFF
--- a/src/components/ConfigEditor/Auth/index.ts
+++ b/src/components/ConfigEditor/Auth/index.ts
@@ -1,4 +1,4 @@
 export { Auth } from './Auth';
 export type { Props as AuthProps } from './Auth';
 export { AuthMethod } from './types';
-export { convertLegacyAuthProps, getTLSProps as convertLegacyTLSProps } from './utils';
+export { convertLegacyAuthProps } from './utils';

--- a/src/components/ConfigEditor/Auth/index.ts
+++ b/src/components/ConfigEditor/Auth/index.ts
@@ -1,4 +1,4 @@
 export { Auth } from './Auth';
 export type { Props as AuthProps } from './Auth';
 export { AuthMethod } from './types';
-export { convertLegacyAuthProps } from './utils';
+export { convertLegacyAuthProps, getTLSProps as convertLegacyTLSProps } from './utils';

--- a/src/components/ConfigEditor/Auth/utils.ts
+++ b/src/components/ConfigEditor/Auth/utils.ts
@@ -1,6 +1,6 @@
 import { Props as AuthProps } from './Auth';
 import { AuthMethod, Header, CustomMethodId } from './types';
-import { CommonConfig, Config, OnChangeHandler, OnCommonChangeHandler } from '../types';
+import { Config, OnChangeHandler } from '../types';
 
 const headerNamePrefix = 'httpHeaderName';
 const headerValuePrefix = 'httpHeaderValue';
@@ -82,7 +82,7 @@ export function getBasicAuthProps<C extends Config = Config>(
   };
 }
 
-export function getTLSProps<C extends CommonConfig>(config: C, onChange: OnCommonChangeHandler<C>): AuthProps['TLS'] {
+export function getTLSProps<C extends Config>(config: C, onChange: OnChangeHandler<C>): AuthProps['TLS'] {
   return {
     selfSignedCertificate: {
       enabled: Boolean(config.jsonData.tlsAuthWithCACert),

--- a/src/components/ConfigEditor/Auth/utils.ts
+++ b/src/components/ConfigEditor/Auth/utils.ts
@@ -82,7 +82,7 @@ export function getBasicAuthProps<C extends Config = Config>(
   };
 }
 
-export function getTLSProps<C extends Config>(config: C, onChange: OnChangeHandler<C>): AuthProps['TLS'] {
+export function getTLSProps<C extends Config = Config>(config: C, onChange: OnChangeHandler<C>): AuthProps['TLS'] {
   return {
     selfSignedCertificate: {
       enabled: Boolean(config.jsonData.tlsAuthWithCACert),

--- a/src/components/ConfigEditor/Auth/utils.ts
+++ b/src/components/ConfigEditor/Auth/utils.ts
@@ -1,6 +1,6 @@
 import { Props as AuthProps } from './Auth';
 import { AuthMethod, Header, CustomMethodId } from './types';
-import { Config, OnChangeHandler } from '../types';
+import { CommonConfig, Config, OnChangeHandler, OnCommonChangeHandler } from '../types';
 
 const headerNamePrefix = 'httpHeaderName';
 const headerValuePrefix = 'httpHeaderValue';
@@ -82,11 +82,11 @@ export function getBasicAuthProps<C extends Config = Config>(
   };
 }
 
-export function getTLSProps<C extends Config = Config>(config: C, onChange: OnChangeHandler<C>): AuthProps['TLS'] {
+export function getTLSProps<C extends CommonConfig>(config: C, onChange: OnCommonChangeHandler<C>): AuthProps['TLS'] {
   return {
     selfSignedCertificate: {
       enabled: Boolean(config.jsonData.tlsAuthWithCACert),
-      certificateConfigured: config.secureJsonFields.tlsCACert,
+      certificateConfigured: !!config.secureJsonFields?.tlsCACert,
       onToggle: (enabled) =>
         enabled
           ? onChange({
@@ -114,8 +114,8 @@ export function getTLSProps<C extends Config = Config>(config: C, onChange: OnCh
     TLSClientAuth: {
       enabled: config.jsonData.tlsAuth,
       serverName: config.jsonData.serverName,
-      clientCertificateConfigured: config.secureJsonFields.tlsClientCert,
-      clientKeyConfigured: config.secureJsonFields.tlsClientKey,
+      clientCertificateConfigured: !!config.secureJsonFields?.tlsClientCert,
+      clientKeyConfigured: !!config.secureJsonFields?.tlsClientKey,
       onToggle: (enabled) =>
         enabled
           ? onChange({

--- a/src/components/ConfigEditor/Connection/ConnectionSettings.tsx
+++ b/src/components/ConfigEditor/Connection/ConnectionSettings.tsx
@@ -23,9 +23,9 @@ export const ConnectionSettings: <C extends Config = Config>(props: Props<C>) =>
   urlLabel,
   className,
 }) => {
-  const isValidUrl = /^(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$/.test(
-    config.url
-  );
+  const isValidUrl =
+    config.url !== undefined &&
+    /^(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?$/.test(config.url);
 
   const styles = {
     container: css({

--- a/src/components/ConfigEditor/index.ts
+++ b/src/components/ConfigEditor/index.ts
@@ -1,7 +1,9 @@
 export { SecureSocksProxyToggle } from './SecureSocksProxyToggle';
 export { DataSourceDescription } from './DataSourceDescription';
 export { ConfigSection, ConfigSubSection, ConfigDescriptionLink } from './ConfigSection';
-export { Auth, AuthMethod, convertLegacyAuthProps } from './Auth';
+export { Auth, AuthMethod, convertLegacyAuthProps, convertLegacyTLSProps } from './Auth';
 export type { AuthProps } from './Auth';
+export { TLSSettings } from './Auth/tls/TLSSettings';
+export type { Props as TLSSettingsProps } from './Auth/tls/TLSSettings';
 export { ConnectionSettings } from './Connection';
 export { AdvancedHttpSettings } from './AdvancedSettings';

--- a/src/components/ConfigEditor/index.ts
+++ b/src/components/ConfigEditor/index.ts
@@ -1,7 +1,7 @@
 export { SecureSocksProxyToggle } from './SecureSocksProxyToggle';
 export { DataSourceDescription } from './DataSourceDescription';
 export { ConfigSection, ConfigSubSection, ConfigDescriptionLink } from './ConfigSection';
-export { Auth, AuthMethod, convertLegacyAuthProps, convertLegacyTLSProps } from './Auth';
+export { Auth, AuthMethod, convertLegacyAuthProps } from './Auth';
 export type { AuthProps } from './Auth';
 export { TLSSettings } from './Auth/tls/TLSSettings';
 export type { Props as TLSSettingsProps } from './Auth/tls/TLSSettings';

--- a/src/components/ConfigEditor/types.ts
+++ b/src/components/ConfigEditor/types.ts
@@ -1,6 +1,14 @@
 import { DataSourceSettings, DataSourceJsonData, PluginMeta } from '@grafana/data';
 
-export type Config<JSONData extends DataSourceJsonData = any, SecureJSONData = any> =
-  | DataSourceSettings<JSONData, SecureJSONData>
-  | PluginMeta<JSONData>;
+export type Config<JSONData extends DataSourceJsonData = any, SecureJSONData = any> = DataSourceSettings<
+  JSONData,
+  SecureJSONData
+>;
+
+export type AppConfig<JSONData extends DataSourceJsonData = any> = PluginMeta<JSONData>;
+
+export type CommonConfig = Config | AppConfig;
+
 export type OnChangeHandler<C extends Config = Config> = (config: C) => void;
+
+export type OnCommonChangeHandler<C extends CommonConfig = CommonConfig> = (config: C) => void;

--- a/src/components/ConfigEditor/types.ts
+++ b/src/components/ConfigEditor/types.ts
@@ -1,7 +1,6 @@
-import { DataSourceSettings, DataSourceJsonData } from '@grafana/data';
+import { DataSourceSettings, DataSourceJsonData, PluginMeta } from '@grafana/data';
 
-export type Config<JSONData extends DataSourceJsonData = any, SecureJSONData = any> = DataSourceSettings<
-  JSONData,
-  SecureJSONData
->;
+export type Config<JSONData extends DataSourceJsonData = any, SecureJSONData = any> =
+  | DataSourceSettings<JSONData, SecureJSONData>
+  | PluginMeta<JSONData>;
 export type OnChangeHandler<C extends Config = Config> = (config: C) => void;

--- a/src/components/ConfigEditor/types.ts
+++ b/src/components/ConfigEditor/types.ts
@@ -1,14 +1,17 @@
-import { DataSourceSettings, DataSourceJsonData, PluginMeta } from '@grafana/data';
+import { DataSourceSettings, DataSourceJsonData } from '@grafana/data';
 
-export type Config<JSONData extends DataSourceJsonData = any, SecureJSONData = any> = DataSourceSettings<
-  JSONData,
-  SecureJSONData
->;
+type DataSourceExclusiveConfig = {
+  readOnly: DataSourceSettings['readOnly'];
+  url: DataSourceSettings['url'];
+  basicAuth: DataSourceSettings['basicAuth'];
+  basicAuthUser: DataSourceSettings['basicAuthUser'];
+  withCredentials: DataSourceSettings['withCredentials'];
+};
 
-export type AppConfig<JSONData extends DataSourceJsonData = any> = PluginMeta<JSONData>;
-
-export type CommonConfig = Config | AppConfig;
+export type Config<JSONData extends DataSourceJsonData = any, SecureJSONData = {}> = {
+  jsonData: DataSourceSettings<JSONData>['jsonData'];
+  secureJsonData: DataSourceSettings<JSONData, SecureJSONData>['secureJsonData'];
+  secureJsonFields: DataSourceSettings['secureJsonFields'];
+} & Partial<DataSourceExclusiveConfig>;
 
 export type OnChangeHandler<C extends Config = Config> = (config: C) => void;
-
-export type OnCommonChangeHandler<C extends CommonConfig = CommonConfig> = (config: C) => void;


### PR DESCRIPTION
I wanted the ability to use the "TLS settings" form portion in my plugin config editor.
![image](https://github.com/user-attachments/assets/a0f0a01c-5e0b-4b90-8070-8659841ad0b6)

**UPDATE**: I found a way to work with the `<Auth>` component by converting my "token" field into a `CustomMethod`, thus including it under the Authentication section.

~Since the `<TLSSettings>` component is not being exported, this PR aims to make it importable directly.~

**Update**: Importing `<Auth>` is sufficient. However it helps to change the type of `Config` so that I don't have to cast to `any`.

With the following workaround to the strict `Common` type, I am able to use this package without this PR:
```ts
  const initialCommonConnectionConfig = useMemo(() => ({
    jsonData,
    secureJsonData: {},
    secureJsonFields,
  } as unknown as any), [jsonData, secureJsonFields])
```

# Changes in this PR
- Redefine the `Config` type to only contain use a subset of fields from `DataSourceSettings` and `PluginMeta` so most of these components can work with both. Some of the `DataSourceSettings` fields are exclusive, so they are set to optional so as to not exclude the use of `PluginMeta`.
  - Some code needed to be modified to accommodate the possibility that certain fields might be `undefined`.




# Alternative approaches to consider
- **UPDATE:**: Using CustomMethods, I was able to insert part of my form (token) under this `<Auth>` section, eliminating the need to add mechanisms to hide parts of the `<Auth>` component.
- [x] Update "Options" type so that it is compatible with both `DataSourceSettings` and `PluginMeta`, only including fields that are read or changed.
- [ ]  It may be useful to have a "plugin" flag so as to change the textual content of some form subsections, or to remove them when they require specific fields exclusive to the `DataSourceSettings` type.

