### PR TITLE
chore: Auth make it more playwright friendly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.9.4 - 2024-12-18
+
+- Auth: Make AuthMethodSettings select more Playwright friendly.
+
 ## v0.9.3 - 2024-12-13
 
 - Make Auth component to be usable by plugins

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-ui",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "repository": "git@github.com:grafana/plugin-ui.git",
   "author": "Grafana Labs",
   "main": "dist/index.js",

--- a/src/components/ConfigEditor/Auth/auth-method/AuthMethodSettings.tsx
+++ b/src/components/ConfigEditor/Auth/auth-method/AuthMethodSettings.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useMemo, useState } from 'react';
 import { css } from '@emotion/css';
-import { useTheme2, Select } from '@grafana/ui';
+import { useTheme2, Select, Field } from '@grafana/ui';
 import { SelectableValue } from '@grafana/data';
 import { BasicAuth, Props as BasicAuthProps } from './BasicAuth';
 import { ConfigSubSection } from '../../ConfigSection';
@@ -119,11 +119,11 @@ export const AuthMethodSettings = ({
     AuthFieldsComponent = customMethods?.find((m) => m.id === selected)?.component ?? null;
   }
 
-  const title = hasSelect ? 'Authentication methods' : (preparedOptions[0].label ?? '');
+  const title = hasSelect ? 'Authentication methods' : preparedOptions[0].label ?? '';
 
   const description = hasSelect
     ? 'Choose an authentication method to access the data source'
-    : (preparedOptions[0].description ?? '');
+    : preparedOptions[0].description ?? '';
 
   const styles = {
     authMethods: css({
@@ -142,15 +142,18 @@ export const AuthMethodSettings = ({
     <ConfigSubSection title={title} description={description}>
       <div className={styles.authMethods}>
         {hasSelect && (
-          <Select
-            options={preparedOptions}
-            value={selected}
-            onChange={(option) => {
-              setAuthMethodChanged(true);
-              onAuthMethodSelect(option.value!);
-            }}
-            disabled={readOnly}
-          />
+          <Field label="Authentication method">
+            <Select
+              inputId="auth-method-select"
+              options={preparedOptions}
+              value={selected}
+              onChange={(option) => {
+                setAuthMethodChanged(true);
+                onAuthMethodSelect(option.value!);
+              }}
+              disabled={readOnly}
+            />
+          </Field>
         )}
         {AuthFieldsComponent && <div className={styles.selectedMethodFields}>{AuthFieldsComponent}</div>}
       </div>


### PR DESCRIPTION
<img width="632" alt="image" src="https://github.com/user-attachments/assets/b144bb23-0846-4075-8996-a540ed579be3" />

Adds a little `<Field>` component and an `inputId` to the select dropdown so its easier to locate with playwright on e2e tests

Follows the [grafana testing guidelines](https://github.com/grafana/grafana/blob/401265522e584e4e71a1d92d5af311564b1ec33e/contribute/style-guides/testing.md)