### PR TITLE
Fix `Config` type to be compatible with `DataSourceSettings`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 
+## v0.9.6 - 2025-01-20
+
+- Fix `Config` type to be compatible with `DataSourceSettings`
+
 ## v0.9.5 - 2025-01-16
+
 - Query Builder: Add support to disable operations
 
 ## v0.9.4 - 2024-12-18

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-ui",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "repository": "git@github.com:grafana/plugin-ui.git",
   "author": "Grafana Labs",
   "main": "dist/index.js",

--- a/src/components/ConfigEditor/types.ts
+++ b/src/components/ConfigEditor/types.ts
@@ -10,7 +10,7 @@ type DataSourceExclusiveConfig = {
 
 export type Config<JSONData extends DataSourceJsonData = any, SecureJSONData = {}> = {
   jsonData: DataSourceSettings<JSONData>['jsonData'];
-  secureJsonData: DataSourceSettings<JSONData, SecureJSONData>['secureJsonData'];
+  secureJsonData?: DataSourceSettings<JSONData, SecureJSONData>['secureJsonData'];
   secureJsonFields: DataSourceSettings['secureJsonFields'];
 } & Partial<DataSourceExclusiveConfig>;
 


### PR DESCRIPTION
Related to changes in https://github.com/grafana/plugin-ui/pull/113

Fix `Config` type to be compatible with `DataSourceSettings` by making `secureJsonData` be optional https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/types/datasource.ts#L660


<img width="857" alt="image" src="https://github.com/user-attachments/assets/56f8c79d-ee7e-438d-a49c-96c326828658" />


I noticed this when trying to use this package in grafana/grafana and got `Property 'secureJsonData' is optional in type 'DataSourceSettings<DataSourceJsonData, {}>' but required in type '{ jsonData: any; secureJsonData: {} | undefined; secureJsonFields: KeyValue<boolean>; }'` error. 

<img width="1168" alt="image" src="https://github.com/user-attachments/assets/d1b4d8b8-75ac-4ee0-9ef3-7990777ff377" />

With optional `secureJsonData?`:
<img width="890" alt="image" src="https://github.com/user-attachments/assets/1649ba4b-8f3f-40c2-9b47-a592b7cbc221" />
