### PR TITLE
Fix: Incorrect paths in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.10.1 - 2025-01-30
+
+- Fix commonjs resolution errors due to incorrect paths in package.json
+
 ## v0.10.0 - 2025-01-30
 
 - Remove AsyncButtonCascader, Cascader, InlineSwitch and CertificationKey components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.10.1 - 2025-01-30
 
 - Fix commonjs resolution errors due to incorrect paths in package.json
+- Bump UUID dependency to ^11.0.0
 
 ## v0.10.0 - 2025-01-30
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@grafana/plugin-ui",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "repository": "git@github.com:grafana/plugin-ui.git",
   "author": "Grafana Labs",
   "type": "module",
-  "main": "dist/cjs/index.cjs",
+  "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/cjs/index.d.cts",
   "exports": {
@@ -16,7 +16,7 @@
       },
       "require": {
         "types": "./dist/cjs/index.d.cts",
-        "default": "./dist/cjs/index.cjs"
+        "default": "./dist/cjs/index.js"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "@types/react": "18.3.18",
     "@types/react-calendar": "^3.1.2",
     "@types/testing-library__jest-dom": "^5.9.5",
-    "@types/uuid": "^8.3.2",
     "@typescript-eslint/eslint-plugin": "^6.18.0",
     "@typescript-eslint/parser": "^6.18.0",
     "chance": "^1.1.7",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": "git@github.com:grafana/plugin-ui.git",
   "author": "Grafana Labs",
   "type": "module",
-  "main": "dist/cjs/index.js",
+  "main": "dist/cjs/index.cjs",
   "module": "dist/esm/index.js",
   "types": "dist/cjs/index.d.cts",
   "exports": {
@@ -16,7 +16,7 @@
       },
       "require": {
         "types": "./dist/cjs/index.d.cts",
-        "default": "./dist/cjs/index.js"
+        "default": "./dist/cjs/index.cjs"
       }
     }
   },
@@ -46,7 +46,7 @@
     "react-use": "^17.3.1",
     "react-virtualized-auto-sizer": "^1.0.6",
     "sql-formatter-plus": "^1.3.6",
-    "uuid": "^8.3.2"
+    "uuid": "^11.0.0"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.3",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -34,7 +34,7 @@ export default [
       {
         format: 'cjs',
         sourcemap: true,
-        dir: path.dirname(pkg.main),
+        file: pkg.main,
         ...legacyOutputDefaults,
       },
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1600,7 +1600,6 @@ __metadata:
     "@types/react": "npm:18.3.18"
     "@types/react-calendar": "npm:^3.1.2"
     "@types/testing-library__jest-dom": "npm:^5.9.5"
-    "@types/uuid": "npm:^8.3.2"
     "@typescript-eslint/eslint-plugin": "npm:^6.18.0"
     "@typescript-eslint/parser": "npm:^6.18.0"
     chance: "npm:^1.1.7"
@@ -4237,13 +4236,6 @@ __metadata:
   version: 0.0.3
   resolution: "@types/use-sync-external-store@npm:0.0.3"
   checksum: 10c0/82824c1051ba40a00e3d47964cdf4546a224e95f172e15a9c62aa3f118acee1c7518b627a34f3aa87298a2039f982e8509f92bfcc18bea7c255c189c293ba547
-  languageName: node
-  linkType: hard
-
-"@types/uuid@npm:^8.3.2":
-  version: 8.3.4
-  resolution: "@types/uuid@npm:8.3.4"
-  checksum: 10c0/b9ac98f82fcf35962317ef7dc44d9ac9e0f6fdb68121d384c88fe12ea318487d5585d3480fa003cf28be86a3bbe213ca688ba786601dce4a97724765eb5b1cf2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1639,7 +1639,7 @@ __metadata:
     storybook: "npm:^8.5.2"
     ts-node: "npm:^10.9.1"
     typescript: "npm:^5.7.3"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^11.0.0"
   peerDependencies:
     "@grafana/data": ^10.4.0 || ^11.0.0
     "@grafana/e2e-selectors": ^10.4.0 || ^11.0.0
@@ -15036,12 +15036,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
+"uuid@npm:^11.0.0":
+  version: 11.0.5
+  resolution: "uuid@npm:11.0.5"
   bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
+    uuid: dist/esm/bin/uuid
+  checksum: 10c0/6f59f0c605e02c14515401084ca124b9cb462b4dcac866916a49862bcf831874508a308588c23a7718269226ad11a92da29b39d761ad2b86e736623e3a33b6e7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
CommonJS bundles are resolved via the package.json `main` and `exports['.'].require` properties in package.json but they currently point to non-existant `.cjs` files. This PR updates the rollup config to resolve this.

Builds now generate the `.cjs` files that were previously being written to the filesystem as `.js`.

![image](https://github.com/user-attachments/assets/00acf654-1951-4d9b-a23a-a54ab7497213)
