### PR TITLE
re-add test mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.10.2 - 2025-02-04
+
+- Re-add test mock exports
+
 ## v0.10.1 - 2025-01-30
 
 - Fix commonjs resolution errors due to incorrect paths in package.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-ui",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "repository": "git@github.com:grafana/plugin-ui.git",
   "author": "Grafana Labs",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@
  */
 export * from './components';
 export { SqlDatasource } from './datasource/SqlDatasource';
+export * from './test/mocks';


### PR DESCRIPTION
The mocks import was removed here: https://github.com/grafana/plugin-ui/pull/97

However mocks are still used on several enterprise packages so this reversal will allow us to migrate away from experimental, eg: https://github.com/grafana/plugins-private/blob/13be0ff2e6bc32838ef9875e21053a46af9e8c27/plugins/grafana-servicenow-datasource/src/components/__fixtures__/Datasource.ts#L3-L3