### PR TITLE
Chore: CVE-2024-21489

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -184,6 +184,7 @@
     "comparitor",
     "pangea",
     "attw",
+    "uplot",
     "arethetypeswrong"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -121,5 +121,8 @@
   "files": [
     "dist"
   ],
+  "resolutions": {
+    "uplot": "^1.6.31"
+  },
   "packageManager": "yarn@4.6.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14955,10 +14955,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uplot@npm:1.6.30":
-  version: 1.6.30
-  resolution: "uplot@npm:1.6.30"
-  checksum: 10c0/af803fc23b9614979596c06dec55aa6967e748071b118fb960c5604b6095bb1dc511c1fa33d7d4990159db886475a617decf15e19691381f73f159fed4b1f32b
+"uplot@npm:^1.6.31":
+  version: 1.6.31
+  resolution: "uplot@npm:1.6.31"
+  checksum: 10c0/b1b03ebb23bda148c16e085006db183f93e99c63dd457863217c81fe7f9d99d680b2bf18f5ea2e39c39df67e20d7bae4e7730853c0af9c86c0eb8e8004e2f8ed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fix resolution of uplot version.

Alternatively we could update `@grafana/data` but this seems simpler