### PR TITLE
Use import instead of require in SQL language definition + prepare 0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.10.4 - 2025-02-19
+
+- Use `import` instead of `require` in SQL language definition
+
 ## v0.10.3 - 2025-02-04
 
 - Re-add `generateOptions` mock helper

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-ui",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "repository": "git@github.com:grafana/plugin-ui.git",
   "author": "Grafana Labs",
   "type": "module",

--- a/src/components/SQLEditor/standardSql/definition.ts
+++ b/src/components/SQLEditor/standardSql/definition.ts
@@ -6,7 +6,7 @@ const standardSQLLanguageDefinition: LanguageDefinition = {
   extensions: ['.sql'],
   aliases: ['sql'],
   mimetypes: [],
-  loader: () => require('./language'),
+  loader: () => import('./language'),
 
   completionProvider: getStandardSQLCompletionProvider,
 };


### PR DESCRIPTION
`require` breaks the Athena plugin (and Yugabyte) when I update to the latest version of plugin-ui. I assume the changes in the build process we did recently require `import` (heh) to be used here. I tested it locally with Athena and [Yugabyte](https://github.com/grafana/plugin-ui/commit/33971841e299ae4e1704b0d034144440921f6eaa) and both autocomplete and syntax highlighting features work with this change
<img width="650" alt="Screenshot 2025-02-18 at 18 11 31" src="https://github.com/user-attachments/assets/38eee5ed-3d73-4854-bf4f-dac2e8969e28" />
