### PR TITLE
Relax peer dependencies to work with everything newer than `10.4.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.10.5 - 2025-04-07
+
+- Relax peer dependencies to work with dependencies `=> 10.4.0`
+
 ## v0.10.4 - 2025-02-19
 
 - Use `import` instead of `require` in SQL language definition

--- a/package.json
+++ b/package.json
@@ -110,10 +110,10 @@
     "typescript": "^5.7.3"
   },
   "peerDependencies": {
-    "@grafana/data": "^10.4.0 || ^11.0.0",
-    "@grafana/e2e-selectors": "^10.4.0 || ^11.0.0",
-    "@grafana/runtime": "^10.4.0 || ^11.0.0",
-    "@grafana/ui": "^10.4.0 || ^11.0.0",
+    "@grafana/data": ">=10.4.0",
+    "@grafana/e2e-selectors": ">=10.4.0",
+    "@grafana/runtime": ">=10.4.0",
+    "@grafana/ui": ">=10.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rxjs": "^7.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-ui",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "repository": "git@github.com:grafana/plugin-ui.git",
   "author": "Grafana Labs",
   "type": "module",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1797,10 +1797,10 @@ __metadata:
     typescript: "npm:^5.7.3"
     uuid: "npm:^11.0.0"
   peerDependencies:
-    "@grafana/data": ^10.4.0 || ^11.0.0
-    "@grafana/e2e-selectors": ^10.4.0 || ^11.0.0
-    "@grafana/runtime": ^10.4.0 || ^11.0.0
-    "@grafana/ui": ^10.4.0 || ^11.0.0
+    "@grafana/data": ">=10.4.0"
+    "@grafana/e2e-selectors": ">=10.4.0"
+    "@grafana/runtime": ">=10.4.0"
+    "@grafana/ui": ">=10.4.0"
     react: ^18.2.0
     react-dom: ^18.2.0
     rxjs: ^7.8.1


### PR DESCRIPTION
https://github.com/grafana/grafana-dash-app/actions/runs/14313083700/job/40112690489?pr=34 fails because we need `@grafana/data@12.0.0`