### PR TITLE
Change repository field in package.json to use object format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "@grafana/plugin-ui",
   "version": "0.10.7",
-  "repository": "git@github.com:grafana/plugin-ui.git",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/grafana/plugin-ui.git"
+  },
   "author": "Grafana Labs",
   "type": "module",
   "main": "dist/cjs/index.cjs",


### PR DESCRIPTION
This was a warning in the npm publish step `npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.`