### PR TITLE
Chore: Define `AccessoryButton` types correctly

### DIFF
--- a/src/components/QueryEditor/AccessoryButton.tsx
+++ b/src/components/QueryEditor/AccessoryButton.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Button, type ButtonProps, useStyles2 } from '@grafana/ui';
 
-interface AccessoryButtonProps extends ButtonProps {}
+type AccessoryButtonProps = ButtonProps & {};
 
 export const AccessoryButton = ({ className, ...props }: AccessoryButtonProps) => {
   const styles = useStyles2(getButtonStyles);


### PR DESCRIPTION
- interfaces can only extend other interfaces (see https://www.typescriptlang.org/docs/handbook/2/objects.html#extending-types)
- in this case, `ButtonProps` is a `type` not an `interface`
- this seems to be working by accident currently, but will not work with changes planned in https://github.com/grafana/grafana/pull/109131