### PR TITLE
QueryBuilderHints: Use useMemo instead of useState 

### DIFF
--- a/src/components/VisualQueryBuilder/components/QueryBuilderHints.tsx
+++ b/src/components/VisualQueryBuilder/components/QueryBuilderHints.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import React, { useMemo } from 'react';
 
-import { type DataSourceApi, type GrafanaTheme2, type PanelData, type QueryHint, type DataQuery } from '@grafana/data';
+import { type DataSourceApi, type GrafanaTheme2, type PanelData, type DataQuery } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import { Button, Tooltip, useStyles2 } from '@grafana/ui';
 

--- a/src/components/VisualQueryBuilder/components/QueryBuilderHints.tsx
+++ b/src/components/VisualQueryBuilder/components/QueryBuilderHints.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, { useState, useEffect } from 'react';
+import React, { useMemo } from 'react';
 
 import { type DataSourceApi, type GrafanaTheme2, type PanelData, type QueryHint, type DataQuery } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
@@ -28,14 +28,13 @@ export const QueryBuilderHints = <TVisualQuery extends VisualQuery, TDataQuery e
   buildDataQueryFromQueryString,
   buildQueryStringFromDataQuery,
 }: Props<TVisualQuery, TDataQuery>) => {
-  const [hints, setHints] = useState<QueryHint[]>([]);
   const styles = useStyles2(getStyles);
 
-  useEffect(() => {
+  const hints = useMemo(() => {
     const dataQuery = buildDataQueryFromQueryString(queryModeller.renderQuery(visualQuery));
     // For now show only actionable hints
     const hints = datasource.getQueryHints?.(dataQuery, data?.series || []).filter((hint) => hint.fix?.action);
-    setHints(hints ?? []);
+    return hints ?? [];
   }, [datasource, visualQuery, data, queryModeller, buildDataQueryFromQueryString]);
 
   return (


### PR DESCRIPTION
I believe the source of a flaky test in Grafana is this set state being triggered from a place where we can't wrap it with act() correctly. 

https://github.com/grafana/grafana/actions/runs/16802657207/job/47587503434#step:6:91

Looking at the code, I don't see the reason why this should be state at all - it looks like it should be just useMemo.