### PR TITLE
SQLEditor: Fix stale closure

### DIFF
--- a/src/components/SQLEditor/hooks/useLatestCallback.ts
+++ b/src/components/SQLEditor/hooks/useLatestCallback.ts
@@ -1,0 +1,23 @@
+import { useRef, useEffect, useMemo } from 'react';
+
+/**
+ * Returns a stable callback that always calls the latest version of the provided callback.
+ * Useful for avoiding stale closures in imperative APIs like Monaco editor callbacks.
+ *
+ * @param callback The callback function that may change between renders (can be undefined)
+ * @returns A stable callback reference that always calls the latest version, or undefined if no callback provided
+ */
+export function useLatestCallback<T extends (...args: any[]) => unknown>(callback: T | undefined): T | undefined {
+  const ref = useRef(callback);
+
+  useEffect(() => {
+    ref.current = callback;
+  });
+
+  const hasCallback = Boolean(callback);
+
+  return useMemo(
+    () => (hasCallback ? (((...args: Parameters<T>) => ref.current!(...args)) as T) : undefined),
+    [hasCallback]
+  );
+}


### PR DESCRIPTION
## What does this PR do? 📓 

This PR resolves a stale closure issue in the SQLEditor component by introducing a `useLatestCallback` hook. This hook ensures the onChange callback _always_ references the latest version, preventing bugs from outdated closures. The `useLatestCallback` function effectively maintains a stable reference to the latest callback.

#### What this fixes: 

- Prevents Stale Closures: Ensures the latest callback is always used.
- Improves Performance: Minimizes unnecessary re-renders.
- Enhances Maintainability: Provides a reusable pattern for similar issues.

Fixes https://github.com/grafana/plugin-ui/issues/172

### Why is this an issue with the Monaco editor?

The Monaco editor's imperative APIs seems to capture initial state in callbacks, leading to stale closures and synchronization issues. The stale closure culprit, _I believe_, is the `onDidChangeModelContent` event handler captures the onChange callback when it's _first_ registered. If onChange is updated later, the handler still uses the old version, leading to a stale closure.

>[!WARNING]
>I wasn't able to test this using symlinks. There is an issue with how the Monaco Editor serves up assets, something do to with bundling. I didn't necessarily feel like debugging this 😆 
>
>I tested this fix by copy/paste files from the `plugin-ui` repository into the `grafana` repository and running locally.

## Demo 🎥 

### Before

https://github.com/user-attachments/assets/2e87368a-50af-4717-a36c-3af4581db280

### After

https://github.com/user-attachments/assets/0eef19ee-388b-4d6e-82e6-e114c8b7397e