### PR TITLE
[SqlQueryEditor] Add support for catalogs and schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.11.0 - 2025-10-06
+
+- Add support for catalog and schema fields in `SqlQueryEditor`
+
 ## v0.10.10 - 2025-08-27
 
 - Fix stale closure in SQLEditor component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-ui",
-  "version": "0.10.10",
+  "version": "0.11.0",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/grafana/plugin-ui.git"

--- a/src/components/QueryEditor/CatalogSelector.tsx
+++ b/src/components/QueryEditor/CatalogSelector.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Select } from '@grafana/ui';
+import { type SelectableValue } from '@grafana/data';
+import { type DB } from './types';
+
+export interface CatalogSelectorProps {
+  db: DB;
+  inputId?: string;
+  value: string | null;
+  onChange: (catalog: string | null) => void;
+}
+
+export const CatalogSelector = ({ db, inputId, value, onChange }: CatalogSelectorProps) => {
+  const [catalogs, setCatalogs] = React.useState<Array<SelectableValue<string>>>([]);
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  React.useEffect(() => {
+    const loadCatalogs = async () => {
+      if (!db.catalogs) {
+        return;
+      }
+
+      setIsLoading(true);
+      try {
+        const catalogList = await db.catalogs();
+        const catalogOptions = catalogList.map((catalog) => ({
+          label: catalog,
+          value: catalog,
+        }));
+        setCatalogs(catalogOptions);
+      } catch (error) {
+        console.error('Error loading catalogs:', error);
+        setCatalogs([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadCatalogs();
+  }, [db]);
+
+  const handleChange = (selectable: SelectableValue<string>) => {
+    onChange(selectable?.value || null);
+  };
+
+  const selectedValue = catalogs.find((catalog) => catalog.value === value) || null;
+
+  return (
+    <Select
+      inputId={inputId}
+      options={catalogs}
+      value={selectedValue}
+      onChange={handleChange}
+      isLoading={isLoading}
+      placeholder="Select catalog"
+      isClearable
+      allowCustomValue
+      disabled={isLoading}
+      menuShouldPortal={true}
+    />
+  );
+};

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -14,9 +14,11 @@ import { VisualEditor } from './visual-query-builder/VisualEditor';
 import { type SqlDatasource } from '../../datasource/SqlDatasource';
 import { Space } from './Space';
 
-interface Props extends QueryEditorProps<SqlDatasource, SQLQuery, SQLOptions> {}
+interface Props extends QueryEditorProps<SqlDatasource, SQLQuery, SQLOptions> {
+  enableCatalogs?: boolean;
+}
 
-export function SqlQueryEditor({ datasource, query, onChange, onRunQuery, range }: Props) {
+export function SqlQueryEditor({ datasource, query, onChange, onRunQuery, range, enableCatalogs = false }: Props) {
   const [isQueryRunnable, setIsQueryRunnable] = useState(true);
   const db = datasource.getDB();
   const defaultDataset = datasource.dataset;
@@ -83,6 +85,7 @@ export function SqlQueryEditor({ datasource, query, onChange, onRunQuery, range 
         db={db}
         defaultDataset={defaultDataset || ''}
         enableDatasets={!db.disableDatasets}
+        enableCatalogs={enableCatalogs}
         onChange={onQueryHeaderChange}
         onRunQuery={onRunQuery}
         onQueryRowChange={setQueryRowFilter}

--- a/src/components/QueryEditor/QueryEditor.tsx
+++ b/src/components/QueryEditor/QueryEditor.tsx
@@ -14,11 +14,9 @@ import { VisualEditor } from './visual-query-builder/VisualEditor';
 import { type SqlDatasource } from '../../datasource/SqlDatasource';
 import { Space } from './Space';
 
-interface Props extends QueryEditorProps<SqlDatasource, SQLQuery, SQLOptions> {
-  enableCatalogs?: boolean;
-}
+interface Props extends QueryEditorProps<SqlDatasource, SQLQuery, SQLOptions> {}
 
-export function SqlQueryEditor({ datasource, query, onChange, onRunQuery, range, enableCatalogs = false }: Props) {
+export function SqlQueryEditor({ datasource, query, onChange, onRunQuery, range }: Props) {
   const [isQueryRunnable, setIsQueryRunnable] = useState(true);
   const db = datasource.getDB();
   const defaultDataset = datasource.dataset;
@@ -85,7 +83,7 @@ export function SqlQueryEditor({ datasource, query, onChange, onRunQuery, range,
         db={db}
         defaultDataset={defaultDataset || ''}
         enableDatasets={!db.disableDatasets}
-        enableCatalogs={enableCatalogs}
+        enableCatalogs={db.disableCatalogs === false}
         onChange={onQueryHeaderChange}
         onRunQuery={onRunQuery}
         onQueryRowChange={setQueryRowFilter}

--- a/src/components/QueryEditor/QueryHeader.test.tsx
+++ b/src/components/QueryEditor/QueryHeader.test.tsx
@@ -114,6 +114,55 @@ describe('QueryHeader - Catalog and Schema Selectors', () => {
     jest.clearAllMocks();
   });
 
+  describe('Default Catalog Behavior', () => {
+    it('should disable catalogs by default when disableCatalogs is undefined', () => {
+      // Test with a DB that has no disableCatalogs property (undefined)
+      const dbWithUndefinedCatalogs = { ...mockDB };
+      delete (dbWithUndefinedCatalogs as any).disableCatalogs;
+
+      // Remove enableCatalogs from props to test db.disableCatalogs behavior
+      const { enableCatalogs, ...propsWithoutEnableCatalogs } = defaultProps;
+
+      render(<QueryHeader {...propsWithoutEnableCatalogs} db={dbWithUndefinedCatalogs} />);
+
+      // Should not render catalog selectors when disableCatalogs is undefined (default behavior)
+      expect(screen.queryByTestId('catalog-selector')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('schema-selector')).not.toBeInTheDocument();
+      expect(screen.queryByText('Catalog')).not.toBeInTheDocument();
+      expect(screen.queryByText('Schema')).not.toBeInTheDocument();
+    });
+
+    it('should disable catalogs when disableCatalogs is explicitly true', () => {
+      const dbWithDisabledCatalogs = { ...mockDB, disableCatalogs: true };
+
+      // Remove enableCatalogs from props to test db.disableCatalogs behavior
+      const { enableCatalogs, ...propsWithoutEnableCatalogs } = defaultProps;
+
+      render(<QueryHeader {...propsWithoutEnableCatalogs} db={dbWithDisabledCatalogs} />);
+
+      // Should not render catalog selectors when disableCatalogs is true
+      expect(screen.queryByTestId('catalog-selector')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('schema-selector')).not.toBeInTheDocument();
+      expect(screen.queryByText('Catalog')).not.toBeInTheDocument();
+      expect(screen.queryByText('Schema')).not.toBeInTheDocument();
+    });
+
+    it('should enable catalogs only when disableCatalogs is explicitly false', () => {
+      const dbWithEnabledCatalogs = { ...mockDB, disableCatalogs: false };
+
+      // Remove enableCatalogs from props to test db.disableCatalogs behavior
+      const { enableCatalogs, ...propsWithoutEnableCatalogs } = defaultProps;
+
+      render(<QueryHeader {...propsWithoutEnableCatalogs} db={dbWithEnabledCatalogs} />);
+
+      // Should render catalog selectors when disableCatalogs is explicitly false
+      expect(screen.getByTestId('catalog-selector')).toBeInTheDocument();
+      expect(screen.getByTestId('schema-selector')).toBeInTheDocument();
+      expect(screen.getByText('Catalog')).toBeInTheDocument();
+      expect(screen.getByText('Schema')).toBeInTheDocument();
+    });
+  });
+
   describe('Catalog Selector Rendering', () => {
     it('should render catalog selector when enableCatalogs is true', () => {
       render(<QueryHeader {...defaultProps} enableCatalogs={true} />);

--- a/src/components/QueryEditor/QueryHeader.test.tsx
+++ b/src/components/QueryEditor/QueryHeader.test.tsx
@@ -1,0 +1,537 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryHeader } from './QueryHeader';
+import { EditorMode, QueryFormat, type DB } from './types';
+import { applyQueryDefaults } from './defaults';
+
+// Mock the child components
+jest.mock('./CatalogSelector', () => ({
+  CatalogSelector: ({ value, onChange, inputId }: any) => (
+    <select
+      data-testid="catalog-selector"
+      data-input-id={inputId}
+      value={value || ''}
+      onChange={(e) => onChange(e.target.value || null)}
+    >
+      <option value="">Select catalog</option>
+      <option value="catalog1">Catalog 1</option>
+      <option value="catalog2">Catalog 2</option>
+    </select>
+  ),
+}));
+
+jest.mock('./SchemaSelector', () => ({
+  SchemaSelector: ({ value, onChange, catalog, inputId }: any) => (
+    <select
+      data-testid="schema-selector"
+      data-input-id={inputId}
+      value={value || ''}
+      onChange={(e) => onChange(e.target.value || null)}
+      disabled={!catalog}
+    >
+      <option value="">Select schema</option>
+      <option value="schema1">Schema 1</option>
+      <option value="schema2">Schema 2</option>
+    </select>
+  ),
+}));
+
+jest.mock('./DatasetSelector', () => ({
+  DatasetSelector: ({ value, onChange }: any) => (
+    <select
+      data-testid="dataset-selector"
+      value={value || ''}
+      onChange={(e) => onChange({ value: e.target.value || null })}
+    >
+      <option value="">Select dataset</option>
+      <option value="dataset1">Dataset 1</option>
+    </select>
+  ),
+}));
+
+jest.mock('./TableSelector', () => ({
+  TableSelector: ({ value, onChange }: any) => (
+    <select
+      data-testid="table-selector"
+      value={value || ''}
+      onChange={(e) => onChange({ value: e.target.value || null })}
+    >
+      <option value="">Select table</option>
+      <option value="table1">Table 1</option>
+    </select>
+  ),
+}));
+
+jest.mock('./RunQueryButton', () => ({
+  RunQueryButton: ({ onClick }: any) => (
+    <button data-testid="run-query-button" onClick={onClick}>
+      Run Query
+    </button>
+  ),
+}));
+
+jest.mock('./ConfirmModal', () => ({
+  ConfirmModal: ({ isOpen }: any) => (isOpen ? <div data-testid="confirm-modal">Confirm Modal</div> : null),
+}));
+
+const mockDB: DB = {
+  datasets: jest.fn().mockResolvedValue(['dataset1']),
+  catalogs: jest.fn().mockResolvedValue(['catalog1', 'catalog2']),
+  schemas: jest.fn().mockResolvedValue(['schema1', 'schema2']),
+  tables: jest.fn().mockResolvedValue(['table1']),
+  fields: jest.fn().mockResolvedValue([]),
+  validateQuery: jest.fn().mockResolvedValue({ isValid: true, error: '', isError: false, query: {} }),
+  dsID: jest.fn().mockReturnValue(1),
+  lookup: jest.fn().mockResolvedValue([]),
+  getSqlCompletionProvider: jest.fn().mockReturnValue({}),
+  functions: jest.fn().mockResolvedValue([]),
+};
+
+const defaultProps = {
+  db: mockDB,
+  defaultDataset: 'defaultDataset',
+  enableDatasets: false,
+  enableCatalogs: false,
+  query: applyQueryDefaults({
+    refId: 'A',
+    format: QueryFormat.Table,
+    editorMode: EditorMode.Builder,
+  }),
+  onChange: jest.fn(),
+  onRunQuery: jest.fn(),
+  onQueryRowChange: jest.fn(),
+  queryRowFilter: {
+    filter: false,
+    group: false,
+    order: false,
+    preview: false,
+  },
+  isQueryRunnable: true,
+};
+
+describe('QueryHeader - Catalog and Schema Selectors', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Catalog Selector Rendering', () => {
+    it('should render catalog selector when enableCatalogs is true', () => {
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} />);
+
+      expect(screen.getByTestId('catalog-selector')).toBeInTheDocument();
+      expect(screen.getByText('Catalog')).toBeInTheDocument();
+    });
+
+    it('should not render catalog selector when enableCatalogs is false', () => {
+      render(<QueryHeader {...defaultProps} enableCatalogs={false} />);
+
+      expect(screen.queryByTestId('catalog-selector')).not.toBeInTheDocument();
+      expect(screen.queryByText('Catalog')).not.toBeInTheDocument();
+    });
+
+    it('should render catalog selector with custom label', () => {
+      const customLabels = new Map([['catalog', 'Custom Catalog Label']]);
+
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} labels={customLabels} />);
+
+      expect(screen.getByText('Custom Catalog Label')).toBeInTheDocument();
+    });
+
+    it('should render catalog selector with correct input ID', () => {
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} />);
+
+      const catalogSelector = screen.getByTestId('catalog-selector');
+      const inputId = catalogSelector.getAttribute('data-input-id');
+      expect(inputId).toMatch(/^sql-catalog-/);
+    });
+
+    it('should pass current catalog value to CatalogSelector', () => {
+      const queryWithCatalog = applyQueryDefaults({
+        ...defaultProps.query,
+        catalog: 'catalog1',
+      });
+
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} query={queryWithCatalog} />);
+
+      const catalogSelector = screen.getByTestId('catalog-selector');
+      expect(catalogSelector).toHaveValue('catalog1');
+    });
+
+    it('should handle undefined catalog value correctly', () => {
+      const queryWithoutCatalog = applyQueryDefaults({
+        ...defaultProps.query,
+        catalog: undefined,
+      });
+
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} query={queryWithoutCatalog} />);
+
+      const catalogSelector = screen.getByTestId('catalog-selector');
+      expect(catalogSelector).toHaveValue('');
+    });
+  });
+
+  describe('Schema Selector Rendering', () => {
+    it('should render schema selector when enableCatalogs is true', () => {
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} />);
+
+      expect(screen.getByTestId('schema-selector')).toBeInTheDocument();
+      expect(screen.getByText('Schema')).toBeInTheDocument();
+    });
+
+    it('should not render schema selector when enableCatalogs is false', () => {
+      render(<QueryHeader {...defaultProps} enableCatalogs={false} />);
+
+      expect(screen.queryByTestId('schema-selector')).not.toBeInTheDocument();
+      expect(screen.queryByText('Schema')).not.toBeInTheDocument();
+    });
+
+    it('should render schema selector with custom label', () => {
+      const customLabels = new Map([['schema', 'Custom Schema Label']]);
+
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} labels={customLabels} />);
+
+      expect(screen.getByText('Custom Schema Label')).toBeInTheDocument();
+    });
+
+    it('should render schema selector with correct input ID', () => {
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} />);
+
+      const schemaSelector = screen.getByTestId('schema-selector');
+      const inputId = schemaSelector.getAttribute('data-input-id');
+      expect(inputId).toMatch(/^sql-schema-/);
+    });
+
+    it('should pass current schema value to SchemaSelector', () => {
+      const queryWithSchema = applyQueryDefaults({
+        ...defaultProps.query,
+        catalog: 'catalog1',
+        schema: 'schema1',
+      });
+
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} query={queryWithSchema} />);
+
+      const schemaSelector = screen.getByTestId('schema-selector');
+      expect(schemaSelector).toHaveValue('schema1');
+    });
+
+    it('should handle undefined schema value correctly', () => {
+      const queryWithoutSchema = applyQueryDefaults({
+        ...defaultProps.query,
+        catalog: 'catalog1',
+        schema: undefined,
+      });
+
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} query={queryWithoutSchema} />);
+
+      const schemaSelector = screen.getByTestId('schema-selector');
+      expect(schemaSelector).toHaveValue('');
+    });
+
+    it('should pass catalog value to SchemaSelector', () => {
+      const queryWithCatalog = applyQueryDefaults({
+        ...defaultProps.query,
+        catalog: 'catalog1',
+      });
+
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} query={queryWithCatalog} />);
+
+      // The schema selector should receive the catalog value
+      // This is tested indirectly through the mocked component behavior
+      const schemaSelector = screen.getByTestId('schema-selector');
+      expect(schemaSelector).not.toBeDisabled();
+    });
+  });
+
+  describe('Catalog Change Handler', () => {
+    it('should call onChange with updated catalog when catalog changes', async () => {
+      const user = userEvent.setup();
+      const onChange = jest.fn();
+
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} onChange={onChange} />);
+
+      const catalogSelector = screen.getByTestId('catalog-selector');
+      await user.selectOptions(catalogSelector, 'catalog1');
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          catalog: 'catalog1',
+          schema: undefined,
+          table: undefined,
+          sql: undefined,
+          rawSql: '',
+        })
+      );
+    });
+
+    it('should not call onChange if catalog value is the same', async () => {
+      const user = userEvent.setup();
+      const onChange = jest.fn();
+      const queryWithCatalog = applyQueryDefaults({
+        ...defaultProps.query,
+        catalog: 'catalog1',
+      });
+
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} query={queryWithCatalog} onChange={onChange} />);
+
+      const catalogSelector = screen.getByTestId('catalog-selector');
+      await user.selectOptions(catalogSelector, 'catalog1');
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('should reset schema, table, sql, and rawSql when catalog changes', async () => {
+      const user = userEvent.setup();
+      const onChange = jest.fn();
+      const queryWithData = applyQueryDefaults({
+        ...defaultProps.query,
+        catalog: 'oldCatalog',
+        schema: 'oldSchema',
+        table: 'oldTable',
+        rawSql: 'SELECT * FROM table',
+      });
+
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} query={queryWithData} onChange={onChange} />);
+
+      const catalogSelector = screen.getByTestId('catalog-selector');
+      await user.selectOptions(catalogSelector, 'catalog1');
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          catalog: 'catalog1',
+          schema: undefined,
+          table: undefined,
+          sql: undefined,
+          rawSql: '',
+        })
+      );
+    });
+
+    it('should handle null catalog value correctly', async () => {
+      const user = userEvent.setup();
+      const onChange = jest.fn();
+      const queryWithCatalog = applyQueryDefaults({
+        ...defaultProps.query,
+        catalog: 'catalog1',
+      });
+
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} query={queryWithCatalog} onChange={onChange} />);
+
+      const catalogSelector = screen.getByTestId('catalog-selector');
+      await user.selectOptions(catalogSelector, '');
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          catalog: undefined,
+          schema: undefined,
+          table: undefined,
+          sql: undefined,
+          rawSql: '',
+        })
+      );
+    });
+  });
+
+  describe('Schema Change Handler', () => {
+    it('should call onChange with updated schema when schema changes', async () => {
+      const user = userEvent.setup();
+      const onChange = jest.fn();
+      const queryWithCatalog = applyQueryDefaults({
+        ...defaultProps.query,
+        catalog: 'catalog1',
+      });
+
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} query={queryWithCatalog} onChange={onChange} />);
+
+      const schemaSelector = screen.getByTestId('schema-selector');
+      await user.selectOptions(schemaSelector, 'schema1');
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          schema: 'schema1',
+          table: undefined,
+          sql: undefined,
+          rawSql: '',
+        })
+      );
+    });
+
+    it('should not call onChange if schema value is the same', async () => {
+      const user = userEvent.setup();
+      const onChange = jest.fn();
+      const queryWithSchema = applyQueryDefaults({
+        ...defaultProps.query,
+        catalog: 'catalog1',
+        schema: 'schema1',
+      });
+
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} query={queryWithSchema} onChange={onChange} />);
+
+      const schemaSelector = screen.getByTestId('schema-selector');
+      await user.selectOptions(schemaSelector, 'schema1');
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('should reset table, sql, and rawSql when schema changes', async () => {
+      const user = userEvent.setup();
+      const onChange = jest.fn();
+      const queryWithData = applyQueryDefaults({
+        ...defaultProps.query,
+        catalog: 'catalog1',
+        schema: 'oldSchema',
+        table: 'oldTable',
+        rawSql: 'SELECT * FROM table',
+      });
+
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} query={queryWithData} onChange={onChange} />);
+
+      const schemaSelector = screen.getByTestId('schema-selector');
+      await user.selectOptions(schemaSelector, 'schema1');
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          schema: 'schema1',
+          table: undefined,
+          sql: undefined,
+          rawSql: '',
+        })
+      );
+    });
+
+    it('should handle null schema value correctly', async () => {
+      const user = userEvent.setup();
+      const onChange = jest.fn();
+      const queryWithSchema = applyQueryDefaults({
+        ...defaultProps.query,
+        catalog: 'catalog1',
+        schema: 'schema1',
+      });
+
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} query={queryWithSchema} onChange={onChange} />);
+
+      const schemaSelector = screen.getByTestId('schema-selector');
+      await user.selectOptions(schemaSelector, '');
+
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          schema: undefined,
+          table: undefined,
+          sql: undefined,
+          rawSql: '',
+        })
+      );
+    });
+  });
+
+  describe('Conditional Rendering Logic', () => {
+    it('should render both catalog and schema selectors when enableCatalogs is true', () => {
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} />);
+
+      expect(screen.getByTestId('catalog-selector')).toBeInTheDocument();
+      expect(screen.getByTestId('schema-selector')).toBeInTheDocument();
+    });
+
+    it('should not render catalog and schema selectors when enableCatalogs is false', () => {
+      render(<QueryHeader {...defaultProps} enableCatalogs={false} />);
+
+      expect(screen.queryByTestId('catalog-selector')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('schema-selector')).not.toBeInTheDocument();
+    });
+
+    it('should render dataset selector when enableDatasets is true and enableCatalogs is false', () => {
+      render(<QueryHeader {...defaultProps} enableDatasets={true} enableCatalogs={false} />);
+
+      expect(screen.getByTestId('dataset-selector')).toBeInTheDocument();
+      expect(screen.queryByTestId('catalog-selector')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('schema-selector')).not.toBeInTheDocument();
+    });
+
+    it('should not render dataset selector when enableCatalogs is true', () => {
+      render(<QueryHeader {...defaultProps} enableDatasets={true} enableCatalogs={true} />);
+
+      expect(screen.queryByTestId('dataset-selector')).not.toBeInTheDocument();
+      expect(screen.getByTestId('catalog-selector')).toBeInTheDocument();
+      expect(screen.getByTestId('schema-selector')).toBeInTheDocument();
+    });
+
+    it('should always render table selector regardless of catalog/dataset settings', () => {
+      // Test with catalogs enabled
+      const { rerender } = render(<QueryHeader {...defaultProps} enableCatalogs={true} />);
+
+      expect(screen.getByTestId('table-selector')).toBeInTheDocument();
+
+      // Test with datasets enabled
+      rerender(<QueryHeader {...defaultProps} enableDatasets={true} enableCatalogs={false} />);
+
+      expect(screen.getByTestId('table-selector')).toBeInTheDocument();
+
+      // Test with neither enabled
+      rerender(<QueryHeader {...defaultProps} enableDatasets={false} enableCatalogs={false} />);
+
+      expect(screen.getByTestId('table-selector')).toBeInTheDocument();
+    });
+  });
+
+  describe('EditorField Integration', () => {
+    it('should render catalog and schema fields with correct width', () => {
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} />);
+
+      // Check that the fields are rendered within the expected structure
+      expect(screen.getByText('Catalog')).toBeInTheDocument();
+      expect(screen.getByText('Schema')).toBeInTheDocument();
+      expect(screen.getByTestId('catalog-selector')).toBeInTheDocument();
+      expect(screen.getByTestId('schema-selector')).toBeInTheDocument();
+    });
+
+    it('should render fields only in Builder mode', () => {
+      const queryInCodeMode = applyQueryDefaults({
+        ...defaultProps.query,
+        editorMode: EditorMode.Code,
+      });
+
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} query={queryInCodeMode} />);
+
+      expect(screen.queryByTestId('catalog-selector')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('schema-selector')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Labels Customization', () => {
+    it('should use default labels when no custom labels provided', () => {
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} />);
+
+      expect(screen.getByText('Catalog')).toBeInTheDocument();
+      expect(screen.getByText('Schema')).toBeInTheDocument();
+    });
+
+    it('should use custom labels when provided', () => {
+      const customLabels = new Map([
+        ['catalog', 'Database Catalog'],
+        ['schema', 'Database Schema'],
+      ]);
+
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} labels={customLabels} />);
+
+      expect(screen.getByText('Database Catalog')).toBeInTheDocument();
+      expect(screen.getByText('Database Schema')).toBeInTheDocument();
+    });
+
+    it('should use custom label for catalog and default for schema', () => {
+      const customLabels = new Map([['catalog', 'Custom Catalog']]);
+
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} labels={customLabels} />);
+
+      expect(screen.getByText('Custom Catalog')).toBeInTheDocument();
+      expect(screen.getByText('Schema')).toBeInTheDocument();
+    });
+
+    it('should use custom label for schema and default for catalog', () => {
+      const customLabels = new Map([['schema', 'Custom Schema']]);
+
+      render(<QueryHeader {...defaultProps} enableCatalogs={true} labels={customLabels} />);
+
+      expect(screen.getByText('Catalog')).toBeInTheDocument();
+      expect(screen.getByText('Custom Schema')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/QueryEditor/QueryHeader.tsx
+++ b/src/components/QueryEditor/QueryHeader.tsx
@@ -43,7 +43,7 @@ export function QueryHeader({
   db,
   defaultDataset,
   enableDatasets,
-  enableCatalogs = false,
+  enableCatalogs,
   query,
   queryRowFilter,
   onChange,
@@ -57,6 +57,10 @@ export function QueryHeader({
   const [showConfirm, setShowConfirm] = useState(false);
   const toRawSql = getRawSqlFn(db);
   const htmlId = useId();
+
+  // Derive enableCatalogs from db.disableCatalogs when not explicitly provided
+  // Catalogs are disabled by default (when disableCatalogs is undefined or true)
+  const catalogsEnabled = enableCatalogs ?? db.disableCatalogs === false;
 
   const onEditorModeChange = useCallback(
     (newEditorMode: EditorMode) => {
@@ -232,7 +236,7 @@ export function QueryHeader({
           <Space v={0.5} />
 
           <EditorRow>
-            {enableDatasets === true && !enableCatalogs && (
+            {enableDatasets === true && !catalogsEnabled && (
               <EditorField label={labels.get('dataset') || 'Dataset'} width={25}>
                 <DatasetSelector
                   db={db}
@@ -244,7 +248,7 @@ export function QueryHeader({
               </EditorField>
             )}
 
-            {enableCatalogs && (
+            {catalogsEnabled && (
               <>
                 <EditorField label={labels.get('catalog') || 'Catalog'} width={25}>
                   <CatalogSelector
@@ -271,13 +275,13 @@ export function QueryHeader({
               <TableSelector
                 db={db}
                 inputId={`sql-table-${htmlId}`}
-                dataset={enableCatalogs ? undefined : query.dataset || defaultDataset}
-                catalog={enableCatalogs ? (query.catalog === undefined ? null : query.catalog) : undefined}
-                schema={enableCatalogs ? (query.schema === undefined ? null : query.schema) : undefined}
+                dataset={catalogsEnabled ? undefined : query.dataset || defaultDataset}
+                catalog={catalogsEnabled ? (query.catalog === undefined ? null : query.catalog) : undefined}
+                schema={catalogsEnabled ? (query.schema === undefined ? null : query.schema) : undefined}
                 query={query}
                 value={query.table === undefined ? null : query.table}
                 onChange={onTableChange}
-                enableCatalogs={enableCatalogs}
+                enableCatalogs={catalogsEnabled}
                 applyDefault
               />
             </EditorField>

--- a/src/components/QueryEditor/SchemaSelector.tsx
+++ b/src/components/QueryEditor/SchemaSelector.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Select } from '@grafana/ui';
+import { type SelectableValue } from '@grafana/data';
+import { type DB } from './types';
+
+export interface SchemaSelectorProps {
+  db: DB;
+  inputId?: string;
+  catalog: string | null;
+  value: string | null;
+  onChange: (schema: string | null) => void;
+}
+
+export const SchemaSelector = ({ db, inputId, catalog, value, onChange }: SchemaSelectorProps) => {
+  const [schemas, setSchemas] = React.useState<Array<SelectableValue<string>>>([]);
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  React.useEffect(() => {
+    const loadSchemas = async () => {
+      if (!db.schemas || !catalog) {
+        setSchemas([]);
+        return;
+      }
+
+      setIsLoading(true);
+      try {
+        const schemaList = await db.schemas(catalog);
+        const schemaOptions = schemaList.map((schema: string) => ({
+          label: schema,
+          value: schema,
+        }));
+        setSchemas(schemaOptions);
+      } catch (error) {
+        console.error('Error loading schemas:', error);
+        setSchemas([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadSchemas();
+  }, [db, catalog]);
+
+  const handleChange = (selectable: SelectableValue<string>) => {
+    onChange(selectable?.value || null);
+  };
+
+  const selectedValue = schemas.find((schema) => schema.value === value) || null;
+
+  const isDisabled = isLoading || !catalog;
+
+  return (
+    <Select
+      inputId={inputId}
+      options={schemas}
+      value={selectedValue}
+      onChange={handleChange}
+      isLoading={isLoading}
+      placeholder="Select schema"
+      isClearable
+      allowCustomValue
+      disabled={isDisabled}
+      menuShouldPortal={true}
+    />
+  );
+};

--- a/src/components/QueryEditor/index.ts
+++ b/src/components/QueryEditor/index.ts
@@ -15,5 +15,9 @@ export { InputGroup } from './InputGroup';
 export { Space } from './Space';
 export { SqlQueryEditor } from './QueryEditor';
 export { RunQueryButton } from './RunQueryButton';
+export { DatasetSelector } from './DatasetSelector';
+export { CatalogSelector } from './CatalogSelector';
+export { SchemaSelector } from './SchemaSelector';
+export { TableSelector } from './TableSelector';
 
 export * from './types';

--- a/src/components/QueryEditor/types.ts
+++ b/src/components/QueryEditor/types.ts
@@ -65,6 +65,8 @@ export interface SQLQuery extends DataQuery {
   format?: QueryFormat;
   rawSql?: string;
   dataset?: string;
+  catalog?: string;
+  schema?: string;
   table?: string;
   sql?: SQLExpression;
   editorMode?: EditorMode;
@@ -142,7 +144,9 @@ export interface Aggregate {
 export interface DB {
   init?: (datasourceId?: string) => Promise<boolean>;
   datasets: () => Promise<string[]>;
-  tables: (dataset?: string) => Promise<string[]>;
+  catalogs?: () => Promise<string[]>;
+  schemas?: (catalog?: string) => Promise<string[]>;
+  tables: (dataset?: string, catalog?: string, schema?: string) => Promise<string[]>;
   fields: (query: SQLQuery, order?: boolean) => Promise<SQLSelectableValue[]>;
   validateQuery: (query: SQLQuery, range?: TimeRange) => Promise<ValidationResults>;
   dsID: () => number;

--- a/src/components/QueryEditor/types.ts
+++ b/src/components/QueryEditor/types.ts
@@ -157,6 +157,7 @@ export interface DB {
   functions: () => Promise<Aggregate[]>;
   labels?: Map<'dataset', string>;
   disableDatasets?: boolean;
+  disableCatalogs?: boolean;
 }
 
 export interface QueryEditorProps {


### PR DESCRIPTION
Currently, the `SqlQueryEditor` only supports two dropdown fields, namely dataset and table. However, a plugin now needs not only to use three dropdowns, but also it doesn't need to use the dataset field.

Ideally, we should make the component more versatile and extensible, allowing support for a variable number of fields (dropdowns). Even before the changes in this PR, in fact, the dataset field is already an optional field, which can be enabled or disabled using the `disableDatasets` property (of the `DB` type). This seems further prove that we need a refactoring of the component, but that is a more invasive work that could potentially introducing breaking changes that might affect several plugins, thus to be agreed on. 

As such, as a more pragmatic approach and to avoid blocking a user-facing feature for too long, this PR adds a  `disableCatalogs` property, similarly to the `disableDatasets` one. We can then consider working on the refactoring in a separate PR, after discussing it and agreeing on the design choices to implement.

Outcome:
<img width="666" height="96" alt="image" src="https://github.com/user-attachments/assets/c9a8401e-b6a2-47c5-9bcb-80bdf528b08f" />

This PR also adds to basic unit tests for the `SqlQueryEditor`, at least for the changes contained in this PR. Admittedly, the tests are AI-generated.