### PR TITLE
Select: don't open on focus

### DIFF
--- a/src/components/QueryEditor/InlineSelect.tsx
+++ b/src/components/QueryEditor/InlineSelect.tsx
@@ -32,7 +32,7 @@ export function InlineSelect<T>({ label: labelProp, ...props }: InlineSelectProp
           {':'}&nbsp;
         </label>
       )}
-      <Select openMenuOnFocus inputId={id} {...props} components={components} />
+      <Select inputId={id} {...props} components={components} />
     </div>
   );
 }


### PR DESCRIPTION
- immediately opening on focus is bad for a11y, it won't correctly announce any linked labels

For https://github.com/grafana/grafana/issues/118772