### PR TITLE
package.json: pin node + yarn engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,10 @@
   "files": [
     "dist"
   ],
+  "engines": {
+    "node": ">=22.22.2",
+    "yarn": ">=4.6.0"
+  },
   "resolutions": {
     "prismjs": "^1.30.0",
     "uplot": "^1.6.31",


### PR DESCRIPTION
## Summary

- Add an `engines` block to `package.json` pinning `node >=22.22.2` (matching `.nvmrc`) and `yarn >=4.6.0` (matching `packageManager`).
- Helps consumers fail fast on incompatible toolchains and documents the supported range explicitly.
- Part of the Security Hardening Week package-management checklist. Baseline already covered: `enableScripts: false`, `packageManager` pinned, no git-based deps, npm trusted publishing.

## Test plan

- [x] `yarn install --immutable`
- [x] `yarn typecheck`
- [x] `yarn test:ci`
- [x] `yarn build`