### PR TITLE
renovate: add minimumReleaseAge and security packageRules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,6 @@
   "extends": [
     "github>grafana/grafana-renovate-config//presets/data-sources/base"
   ],
-  "minimumReleaseAge": "3 days",
   "prConcurrentLimit": 10,
   "vulnerabilityAlerts": {
     "labels": ["security"],

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,37 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>grafana/grafana-renovate-config//presets/data-sources/base"
+  ],
+  "minimumReleaseAge": "3 days",
+  "prConcurrentLimit": 10,
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "prPriority": 10
+  },
+  "packageRules": [
+    {
+      "description": "Disable minimum release age for @grafana/* npm packages",
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["@grafana/*"],
+      "minimumReleaseAge": null
+    },
+    {
+      "description": "Disable minimum release age for grafana/* GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["grafana/*"],
+      "minimumReleaseAge": null
+    },
+    {
+      "description": "Group all @grafana/* npm updates",
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["@grafana/*"],
+      "groupName": "grafana monorepo"
+    },
+    {
+      "description": "Group Storybook packages",
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["@storybook/*", "storybook"],
+      "groupName": "storybook"
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Strengthens the Renovate config beyond the inherited `grafana-renovate-config//presets/data-sources/base`:

- `minimumReleaseAge: "3 days"` — npm cooldown so freshly-pushed malicious versions can't be ingested immediately (aligns with the Productivity team direction).
- `@grafana/*` npm and `grafana/*` GitHub Actions are explicitly exempt from the cooldown — internal updates shouldn't be artificially delayed.
- `@grafana/*` npm grouped as `grafana monorepo`; `@storybook/*` + `storybook` grouped as `storybook` — reduces PR noise.
- `vulnerabilityAlerts`: label `security` + `prPriority: 10` — keeps CVE PRs prioritized in review.
- `prConcurrentLimit: 10` (peer convention).

## Out of scope

- **No auto-merge** anywhere — per org guidance, refrain until a centralised strategy lands.
- **No `rangeStrategy: "pin"`** — intentionally deferred until the sibling `security-hardening/dependency-pinning` PR merges, to avoid an immediate Renovate-PR flood.

## Test plan

- [x] JSON valid (parses with `JSON.parse`).
- [x] Will be validated by Renovate on the next dependency-dashboard refresh after merge.