### PR TITLE
workflows: add concurrency groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: CI
 on:
   pull_request:
 permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-and-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - main
 permissions: {}
+
+concurrency:
+  group: publish-npm
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: Publish to NPM Package Registry


### PR DESCRIPTION
## Summary

- `ci.yml`: cancel-in-progress per PR — only the latest push to a branch needs to be validated, saves CI minutes.
- `publish-npm.yml`: serialise on the workflow itself with `cancel-in-progress: false` — releases must not be cancelled mid-publish; serialisation prevents two concurrent publishes racing.

## Not changed in this PR

- `EndBug/version-check` (third-party action) is a candidate for replacement with a shared-workflows equivalent or inline script.
