### PR TITLE
release: 0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## next
+## v0.13.2 - 2026-05-28
 
 - Replace `sql-formatter-plus` with `sql-formatter` for actively maintained SQL formatting.
 - Add `language` prop to `SqlQueryEditor`, `RawEditor`, `QueryEditorRaw`, `VisualEditor`, and `Preview` to support dialect-specific formatting (e.g. `postgresql`, `mysql`, `bigquery`). Defaults to `'sql'` for backward compatibility.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/plugin-ui",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/grafana/plugin-ui.git"


### PR DESCRIPTION
## Summary

Cuts a release of the pending `## next` entries.

This release contains:
- Replace `sql-formatter-plus` with `sql-formatter` for actively maintained SQL formatting.
- Add `language` prop to `SqlQueryEditor`, `RawEditor`, `QueryEditorRaw`, `VisualEditor`, and `Preview` to support dialect-specific formatting (e.g. `postgresql`, `mysql`, `bigquery`). Defaults to `'sql'` for backward compatibility.
