### PR TITLE
fix(publish-npm): install npm via corepack to avoid broken bundled npm

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -46,10 +46,17 @@ jobs:
           cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
 
-      # npm trusted publishing requires version ^11.5.1
-      - name: Install npm version ^11.5.1
+      # npm trusted publishing requires version ^11.5.1.
+      # Use corepack instead of `npm install -g npm@...` because the npm
+      # bundled with some Node 22 patch releases has a broken module tree
+      # (missing `promise-retry` in `@npmcli/arborist`) that breaks
+      # self-upgrade. Corepack manages npm versions independently.
+      - name: Install npm version ^11.5.1 via corepack
         if: steps.version_check.outputs.changed == 'true'
-        run: npm install -g npm@^11.5.1
+        run: |
+          corepack enable npm
+          corepack prepare npm@11.5.1 --activate
+          npm --version
 
       - name: Install dependencies
         if: steps.version_check.outputs.changed == 'true'

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -53,8 +53,9 @@ jobs:
       # Use corepack instead of `npm install -g npm@...` because the bundled
       # npm in the runner image that built 0.13.2 had a corrupt module tree
       # (missing `promise-retry` in `@npmcli/arborist`), so the broken npm
-      # could not upgrade itself. Corepack fetches npm independently.
-      # Example failure:
+      # could not upgrade itself. Corepack fetches npm independently, which
+      # avoids the issue.
+      # An example failure is:
       # https://github.com/grafana/plugin-ui/actions/runs/26574220612/job/78289033224
       #
       # COREPACK_ENABLE_PROJECT_SPEC=0 stops corepack from refusing to run npm

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -46,12 +46,14 @@ jobs:
           cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
 
-      # npm trusted publishing requires version ^11.5.1.
+      # npm trusted publishing requires version ^11.5.1; we pin to an exact
+      # version here because corepack manages exact versions rather than
+      # semver ranges. Bump this pin deliberately when a newer npm is needed.
       # Use corepack instead of `npm install -g npm@...` because the npm
       # bundled with some Node 22 patch releases has a broken module tree
       # (missing `promise-retry` in `@npmcli/arborist`) that breaks
       # self-upgrade. Corepack manages npm versions independently.
-      - name: Install npm version ^11.5.1 via corepack
+      - name: Install npm 11.5.1 via corepack
         if: steps.version_check.outputs.changed == 'true'
         run: |
           corepack enable npm

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -49,12 +49,21 @@ jobs:
       # npm trusted publishing requires version ^11.5.1; we pin to an exact
       # version here because corepack manages exact versions rather than
       # semver ranges. Bump this pin deliberately when a newer npm is needed.
-      # Use corepack instead of `npm install -g npm@...` because the npm
-      # bundled with some Node 22 patch releases has a broken module tree
-      # (missing `promise-retry` in `@npmcli/arborist`) that breaks
-      # self-upgrade. Corepack manages npm versions independently.
+      #
+      # Use corepack instead of `npm install -g npm@...` because the bundled
+      # npm in the runner image that built 0.13.2 had a corrupt module tree
+      # (missing `promise-retry` in `@npmcli/arborist`), so the broken npm
+      # could not upgrade itself. Corepack fetches npm independently.
+      # Example failure:
+      # https://github.com/grafana/plugin-ui/actions/runs/26574220612/job/78289033224
+      #
+      # COREPACK_ENABLE_PROJECT_SPEC=0 stops corepack from refusing to run npm
+      # because package.json pins `packageManager: yarn@...` (yarn itself is
+      # resolved via yarnPath, not corepack, so this does not affect it).
       - name: Install npm 11.5.1 via corepack
         if: steps.version_check.outputs.changed == 'true'
+        env:
+          COREPACK_ENABLE_PROJECT_SPEC: '0'
         run: |
           corepack enable npm
           corepack prepare npm@11.5.1 --activate
@@ -70,4 +79,8 @@ jobs:
 
       - name: Publish package to NPM
         if: steps.version_check.outputs.changed == 'true'
+        env:
+          # The corepack npm shim persists on PATH from the step above; without
+          # this it would abort with "This project is configured to use yarn".
+          COREPACK_ENABLE_PROJECT_SPEC: '0'
         run: npm publish --access public


### PR DESCRIPTION
## Why

`publish-npm.yml` for PR #284's release of 0.13.2 failed at `npm install -g npm@^11.5.1`:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
...
```

Failure: https://github.com/grafana/plugin-ui/actions/runs/26574220612/job/78289033224

Root cause: the bundled npm in the runner image that built 0.13.2 had a corrupt module tree (`promise-retry`, a vendored transitive dep of `@npmcli/arborist`, was missing). The step used that broken npm to upgrade itself — which can't work.

## Fix

Use `corepack` (built into Node 22+) to install npm 11.5.1 independently of the bundled npm:

```diff
- - name: Install npm version ^11.5.1
-   if: steps.version_check.outputs.changed == 'true'
-   run: npm install -g npm@^11.5.1
+ - name: Install npm 11.5.1 via corepack
+   if: steps.version_check.outputs.changed == 'true'
+   env:
+     COREPACK_ENABLE_PROJECT_SPEC: '0'
+   run: |
+     corepack enable npm
+     corepack prepare npm@11.5.1 --activate
+     npm --version
```

This is durable against future Node releases with similar packaging breakage — corepack doesn't depend on the bundled npm.

Note: corepack manages exact versions, so we pin to `11.5.1` rather than the original `^11.5.1` semver range. The pin should be bumped deliberately when a newer npm is needed; the inline comment in the workflow documents this.

### corepack vs the `packageManager` pin

`package.json` pins `"packageManager": "yarn@4.6.0"`. Once npm runs through a corepack shim, corepack enforces that pin and aborts npm with `This project is configured to use yarn` — which would break both `npm --version` and the later `npm publish` step. `COREPACK_ENABLE_PROJECT_SPEC=0` makes corepack ignore the pin when running npm. This is safe for the `yarn install` / `yarn build` steps because yarn is resolved via `yarnPath: .yarn/releases/yarn-4.6.0.cjs`, not corepack.

The env var is set on the corepack step and on the publish step (the `corepack enable` shim persists on `PATH` across steps).

## Test plan

- `publish-npm.yml` only runs on `push: main`, so it is **not** exercised by this PR's checks — validation happens on the next real release.
- Locally reproduced the corepack/`packageManager` conflict (`corepack enable npm` + `npm` in a dir pinned to `yarn@4.6.0` → `This project is configured to use yarn`) and confirmed `COREPACK_ENABLE_PROJECT_SPEC=0` resolves it.
- Confirmed yarn resolves via committed `yarnPath`, so the env var does not affect the yarn steps.
- YAML validated with `js-yaml`.